### PR TITLE
Remove flake8 black

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@ astroid==2.3.3
 black==19.10b0
 callee==0.3.1
 click==7.1.1
-flake8-black==0.1.1
 flake8==3.7.9
 freezegun==0.3.15
 importlib-metadata==1.6.0

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -1,10 +1,9 @@
-import os
 import random
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from os import chdir
-from os.path import abspath, dirname, join, pardir, realpath, split
+from os.path import dirname, realpath
 from pathlib import Path
 from subprocess import run
 from unittest.mock import MagicMock
@@ -485,21 +484,21 @@ class TestTurbot:
         message = Message(someone(), channel, "!turnippattern 100 86")
         await client.on_message(message)
         channel.sent.assert_called_with(
-            "Based on your prices, you will see one of the following patterns this week:\n> **Decreasing**: Prices will continuously fall.\n> **Small Spike**: Prices fall until a spike occurs. The price will go up three more times. Sell on the third increase for maximum profit. Spikes only occur from Monday to Thursday.\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",
+            "Based on your prices, you will see one of the following patterns this week:\n> **Decreasing**: Prices will continuously fall.\n> **Small Spike**: Prices fall until a spike occurs. The price will go up three more times. Sell on the third increase for maximum profit. Spikes only occur from Monday to Thursday.\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",  # noqa: E501
             None,
         )
 
         message = Message(someone(), channel, "!turnippattern 100 99")
         await client.on_message(message)
         channel.sent.assert_called_with(
-            "Based on your prices, you will see one of the following patterns this week:\n> **Random**: Prices are completely random. Sell when it goes over your buying price.\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",
+            "Based on your prices, you will see one of the following patterns this week:\n> **Random**: Prices are completely random. Sell when it goes over your buying price.\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",  # noqa: E501
             None,
         )
 
         message = Message(someone(), channel, "!turnippattern 100 22")
         await client.on_message(message)
         channel.sent.assert_called_with(
-            "Based on your prices, you will see one of the following patterns this week:\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",
+            "Based on your prices, you will see one of the following patterns this week:\n> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.",  # noqa: E501
             None,
         )
 
@@ -771,21 +770,7 @@ class TestTurbot:
         await client.on_message(message)
         channel.sent.assert_called_with(
             "__**All Possible Fossils**__\n"
-            ">>> acanthostega, amber, ammonite, ankylo skull, ankylo tail, ankylo torso, "
-            "anomalocaris, archaeopteryx, archelon skull, archelon tail, australopith, "
-            "brachio chest, brachio pelvis, brachio skull, brachio tail, coprolite, "
-            "deinony tail, deinony torso, dimetrodon skull, dimetrodon torso, dinosaur "
-            "track, diplo chest, diplo neck, diplo pelvis, diplo skull, diplo tail, diplo "
-            "tail tip, dunkleosteus, eusthenopteron, iguanodon skull, iguanodon tail, "
-            "iguanodon torso, juramaia, left megalo side, left ptera wing, left quetzal "
-            "wing, mammoth skull, mammoth torso, megacero skull, megacero tail, megacero "
-            "torso, myllokunmingia, ophthalmo skull, ophthalmo torso, pachy skull, pachy "
-            "tail, parasaur skull, parasaur tail, parasaur torso, plesio body, plesio "
-            "skull, plesio tail, ptera body, quetzal torso, right megalo side, right "
-            "ptera wing, right quetzal wing, sabertooth skull, sabertooth tail, "
-            "shark-tooth pattern, spino skull, spino tail, spino torso, stego skull, "
-            "stego tail, stego torso, t. rex skull, t. rex tail, t. rex torso, tricera "
-            "skull, tricera tail, tricera torso, trilobite",
+            ">>> acanthostega, amber, ammonite, ankylo skull, ankylo tail, ankylo torso, anomalocaris, archaeopteryx, archelon skull, archelon tail, australopith, brachio chest, brachio pelvis, brachio skull, brachio tail, coprolite, deinony tail, deinony torso, dimetrodon skull, dimetrodon torso, dinosaur track, diplo chest, diplo neck, diplo pelvis, diplo skull, diplo tail, diplo tail tip, dunkleosteus, eusthenopteron, iguanodon skull, iguanodon tail, iguanodon torso, juramaia, left megalo side, left ptera wing, left quetzal wing, mammoth skull, mammoth torso, megacero skull, megacero tail, megacero torso, myllokunmingia, ophthalmo skull, ophthalmo torso, pachy skull, pachy tail, parasaur skull, parasaur tail, parasaur torso, plesio body, plesio skull, plesio tail, ptera body, quetzal torso, right megalo side, right ptera wing, right quetzal wing, sabertooth skull, sabertooth tail, shark-tooth pattern, spino skull, spino tail, spino torso, stego skull, stego tail, stego torso, t. rex skull, t. rex tail, t. rex torso, tricera skull, tricera tail, tricera torso, trilobite",  # noqa: E501
             None,
         )
 
@@ -943,7 +928,7 @@ class TestCodebase:
     def test_flake8(self):
         """Assures that the Python codebase passes configured Flake8 checks."""
         chdir(SRC_ROOT)
-        proc = run(["flake8", "--select", "BLK", *SRC_DIRS], capture_output=True)
+        proc = run(["flake8", *SRC_DIRS], capture_output=True)
         assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"
 
     def test_black(self):

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,6 @@ commands =
     pytest --disable-pytest-warnings -vv {posargs}
 
 [flake8]
+ignore = E,W
+select = F,E101,E111,E501
 max-line-length = 90

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -286,13 +286,17 @@ class Turbot(discord.Client):
         logging.debug("logged in as %s", self.user)
 
     def help_command(self, channel, author, params):
-        """Shows this help screen."""
+        """
+        Shows this help screen.
+        """
         members = inspect.getmembers(self, predicate=inspect.ismethod)
         commands = [member[1] for member in members if member[0].endswith("_command")]
         usage = "__**Turbot Help!**__"
         for command in commands:
             doc = command.__doc__.split("|")
             use, params = doc[0], ", ".join([param.strip() for param in doc[1:]])
+            use = inspect.cleandoc(use)
+
             title = f"!{command.__name__.replace('_command', '')}"
             if params:
                 title = f"{title} {params}"
@@ -303,11 +307,15 @@ class Turbot(discord.Client):
         return usage, None
 
     def hello_command(self, channel, author, params):
-        """Says hello to you."""
+        """
+        Says hello to you.
+        """
         return s("hello"), None
 
     def lookup_command(self, channel, author, params):
-        """Gets a user's id given a name. | <name>"""
+        """
+        Gets a user's id given a name. | <name>
+        """
         if not params:
             return s("lookup_no_params"), None
         name = " ".join(params)
@@ -315,7 +323,9 @@ class Turbot(discord.Client):
         return s("lookup", user_id=user_id), None
 
     def sell_command(self, channel, author, params):
-        """Log the price that you can sell turnips for on your island. | <price>"""
+        """
+        Log the price that you can sell turnips for on your island. | <price>
+        """
         if not params:
             return s("sell_no_params"), None
 
@@ -344,7 +354,9 @@ class Turbot(discord.Client):
         return s(key, price=price, name=author, last_price=last_price), None
 
     def buy_command(self, channel, author, params):
-        """Log the price that you can buy turnips from Daisy Mae on your island. | <price>"""
+        """
+        Log the price that you can buy turnips from Daisy Mae on your island. | <price>
+        """
         if not params:
             return s("buy_no_params"), None
 
@@ -361,7 +373,10 @@ class Turbot(discord.Client):
         return s("buy", price=price, name=author), None
 
     def reset_command(self, channel, author, params):
-        """DO NOT USE UNLESS ASKED. Generates a final graph for use with !lastweek and resets all data for all users."""
+        """
+        DO NOT USE UNLESS ASKED. Generates a final graph for use with !lastweek and
+        resets all data for all users.
+        """
         generate_graph(channel, None, LASTWEEKCMD_FILE)
         prices = load_prices()
         buys = prices[prices.kind == "buy"].sort_values(by="timestamp")
@@ -371,13 +386,18 @@ class Turbot(discord.Client):
         return s("reset"), None
 
     def lastweek_command(self, channel, author, params):
-        """Displays the final graph from the last week before the data was reset."""
+        """
+        Displays the final graph from the last week before the data was reset.
+        """
         if not Path(LASTWEEKCMD_FILE).exists():
             return s("lastweek_none"), None
         return s("lastweek"), discord.File(LASTWEEKCMD_FILE)
 
     def graph_command(self, channel, author, params):
-        """Generates a graph of turnip prices for all users. If a user is specified, only graph that users prices. | [user]"""
+        """
+        Generates a graph of turnip prices for all users. If a user is specified, only
+        graph that users prices. | [user]
+        """
         if not params:
             generate_graph(channel, None, GRAPHCMD_FILE)
             return s("graph_all_users"), discord.File(GRAPHCMD_FILE)
@@ -391,7 +411,11 @@ class Turbot(discord.Client):
         return s("graph_user", name=user_name), discord.File(GRAPHCMD_FILE)
 
     def turnippattern_command(self, channel, author, params):
-        """Calculates the patterns you will see in your shop based on Daisy Mae's price on your island and your Monday morning sell price. | <Sunday Buy Price> <Monday Morning Sell Price>"""
+        """
+        Calculates the patterns you will see in your shop based on Daisy Mae's price
+        on your island and your Monday morning sell price. |
+        <Sunday Buy Price> <Monday Morning Sell Price>
+        """
         if len(params) != 2:
             return s("turnippattern_bad_params"), None
 
@@ -424,7 +448,10 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def history_command(self, channel, author, params):
-        """Show the historical turnip prices for a user. If no user is specified, it will display your own prices. | [user]"""
+        """
+        Show the historical turnip prices for a user. If no user is specified, it will
+        display your own prices. | [user]
+        """
         target = author.id if not params else params[0]
         target_name = discord_user_name(channel, target)
         target_id = discord_user_id(channel, target_name)
@@ -441,7 +468,9 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def oops_command(self, channel, author, params):
-        """Remove your last logged turnip price."""
+        """
+        Remove your last logged turnip price.
+        """
         target = author.id
         target_name = discord_user_name(channel, target)
         prices = load_prices()
@@ -450,7 +479,9 @@ class Turbot(discord.Client):
         return s("oops", name=target_name), None
 
     def clear_command(self, channel, author, params):
-        """Clears all of your own historical turnip prices."""
+        """
+        Clears all of your own historical turnip prices.
+        """
         user_id = discord_user_id(channel, str(author))
         prices = load_prices()
         prices = prices[prices.author != user_id]
@@ -470,15 +501,23 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def bestbuy_command(self, channel, author, params):
-        """Finds the best (and most recent) buying prices logged in the last 12 hours."""
+        """
+        Finds the best (and most recent) buying prices logged in the last 12 hours.
+        """
         return self._best(channel, author, "buy")
 
     def bestsell_command(self, channel, author, params):
-        """Finds the best (and most recent) selling prices logged in the last 12 hours."""
+        """
+        Finds the best (and most recent) selling prices logged in the last 12 hours.
+        """
         return self._best(channel, author, "sell")
 
     def collect_command(self, channel, author, params):
-        """Mark fossils as donated to your museum. The names must match the in-game item name, and more than one can be provided if separated by commas. | <list of fossils>"""
+        """
+        Mark fossils as donated to your museum. The names must match the in-game item
+        name, and more than one can be provided if separated by commas.
+        | <list of fossils>
+        """
         if not params:
             return s("collect_no_params"), None
 
@@ -505,7 +544,11 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def uncollect_command(self, channel, author, params):
-        """Unmark fossils as donated to your museum. The names must match the in-game item name, and more than one can be provided if separated by commas. | <list of fossils>"""
+        """
+        Unmark fossils as donated to your museum. The names must match the in-game item
+        name, and more than one can be provided if separated by commas.
+        | <list of fossils>
+        """
         if not params:
             return s("uncollect_no_params"), None
 
@@ -531,7 +574,11 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def fossilsearch_command(self, channel, author, params):
-        """Searches all users to see who needs the listed fossils. The names must match the in-game item name, and more than one can be provided if separated by commas. | <list of fossils>"""
+        """
+        Searches all users to see who needs the listed fossils. The names must match the
+        in-game item name, and more than one can be provided if separated by commas.
+        | <list of fossils>
+        """
         if not params:
             return s("fossilsearch_no_params"), None
 
@@ -559,11 +606,16 @@ class Turbot(discord.Client):
         return "\n".join(lines), None
 
     def allfossils_command(self, channel, author, params):
-        """Shows all possible fossils that you can donate to the museum."""
+        """
+        Shows all possible fossils that you can donate to the museum.
+        """
         return s("allfossils", list=", ".join(sorted(FOSSILS))), None
 
     def listfossils_command(self, channel, author, params):
-        """Lists all fossils that you still need to donate. If a user is provided, it gives the same information for that user instead. | [user]"""
+        """
+        Lists all fossils that you still need to donate. If a user is provided, it gives
+        the same information for that user instead. | [user]
+        """
         target = author.id if not params else params[0]
         target_name = discord_user_name(channel, target)
         target_id = discord_user_id(channel, target_name)
@@ -585,7 +637,10 @@ class Turbot(discord.Client):
         )
 
     def collectedfossils_command(self, channel, author, params):
-        """Lists all fossils that you have already donated. If a user is provided, it gives the same information for that user instead. | [user]"""
+        """
+        Lists all fossils that you have already donated. If a user is provided, it
+        gives the same information for that user instead. | [user]
+        """
         target = author.id if not params else params[0]
         target_name = discord_user_name(channel, target)
         target_id = discord_user_id(channel, target_name)
@@ -607,7 +662,10 @@ class Turbot(discord.Client):
         )
 
     def fossilcount_command(self, channel, author, params):
-        """Provides a count of the number of fossils remaining for the comma-separated list of users. | <list of users>"""
+        """
+        Provides a count of the number of fossils remaining for the comma-separated list
+        of users. | <list of users>
+        """
         if not params:
             return s("fossilcount_no_params"), None
 


### PR DESCRIPTION
I was having issues with flake8-black actually picking up things like unused imports. I don't know but it's weird and a dependency we don't actually need. Refactored the codebase tests to not need it. This also cleans up docstrings as well thanks to fancy `inspect.cleandoc()` function that I just learned about.

I also made it so CI runs on push **and pull requests** because before it was only running on pushes to my fork, which isn't what we want at all.

![tenor](https://user-images.githubusercontent.com/1903876/79401625-7a03f100-7f3e-11ea-9ce3-a52df74956f0.gif)
