### PR TITLE
Add unrecognized fossil feedback to fossilsearch and correct error if predict can't find a buy price

### DIFF
--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -588,9 +588,9 @@ class Turbot(discord.Client):
         invalid = items - valid
 
         fossils = load_fossils()
-        #I think we should still show if the searcher needs the fossil being
-        #searched for, just in case they missed it.
-        #theirs = fossils[fossils.author != author.id]
+        # I think we should still show if the searcher needs the fossil being
+        # searched for, just in case they missed it.
+        # theirs = fossils[fossils.author != author.id]
         theirs = fossils
         them = theirs.author.unique()
         results = defaultdict(list)
@@ -603,21 +603,21 @@ class Turbot(discord.Client):
 
         if not results:
             if len(invalid) > 0:
-                lines=[s("fossil_bad", items=", ".join(sorted(invalid)))]
+                lines = [s("fossil_bad", items=", ".join(sorted(invalid)))]
             else:
                 lines = [s("fossilsearch_noneed")]
-               
+
             return "\n".join(lines), None
 
         lines = [s("fossilsearch_header")]
         for name, needed in results.items():
             need_list = fossils = ", ".join(sorted(needed))
             lines.append(s("fossilsearch_row", name=name, fossils=need_list))
-        
+
         if len(invalid) > 0:
             lines.append(" ")
             lines.append(s("fossil_bad", items=", ".join(sorted(invalid))))
-            
+
         return "\n".join(lines), None
 
     def allfossils_command(self, channel, author, params):
@@ -728,7 +728,7 @@ class Turbot(discord.Client):
 
         recent_buy = yours[yours.kind == "buy"].tail(1)
         if recent_buy.empty:
-            return s("cant_find_buy", name=target_name),None
+            return s("cant_find_buy", name=target_name), None
 
         buy_date = np.datetime64(recent_buy.timestamp.values[0])
         buy_price = int(recent_buy.price)

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -571,7 +571,7 @@ class Turbot(discord.Client):
         if didnt_have:
             lines.append(s("uncollect_already", items=", ".join(sorted(didnt_have))))
         if invalid:
-            lines.append(s("uncollect_bad", items=", ".join(sorted(invalid))))
+            lines.append(s("fossil_bad", items=", ".join(sorted(invalid))))
         return "\n".join(lines), None
 
     def fossilsearch_command(self, channel, author, params):
@@ -585,9 +585,13 @@ class Turbot(discord.Client):
 
         items = set(item.strip().lower() for item in " ".join(params).split(","))
         valid = items.intersection(FOSSILS)
+        invalid = items - valid
 
         fossils = load_fossils()
-        theirs = fossils[fossils.author != author.id]
+        #I think we should still show if the searcher needs the fossil being
+        #searched for, just in case they missed it.
+        #theirs = fossils[fossils.author != author.id]
+        theirs = fossils
         them = theirs.author.unique()
         results = defaultdict(list)
         for fossil in valid:
@@ -598,12 +602,22 @@ class Turbot(discord.Client):
                 results[name].append(fossil)
 
         if not results:
-            return s("fossilsearch_noneed"), None
+            if len(invalid) > 0:
+                lines=[s("fossil_bad", items=", ".join(sorted(invalid)))]
+            else:
+                lines = [s("fossilsearch_noneed")]
+               
+            return "\n".join(lines), None
 
         lines = [s("fossilsearch_header")]
         for name, needed in results.items():
             need_list = fossils = ", ".join(sorted(needed))
             lines.append(s("fossilsearch_row", name=name, fossils=need_list))
+        
+        if len(invalid) > 0:
+            lines.append(" ")
+            lines.append(s("fossil_bad", items=", ".join(sorted(invalid))))
+            
         return "\n".join(lines), None
 
     def allfossils_command(self, channel, author, params):
@@ -714,7 +728,7 @@ class Turbot(discord.Client):
 
         recent_buy = yours[yours.kind == "buy"].tail(1)
         if recent_buy.empty:
-            return s("cant_find_buy", name=target_name)
+            return s("cant_find_buy", name=target_name),None
 
         buy_date = np.datetime64(recent_buy.timestamp.values[0])
         buy_price = int(recent_buy.price)

--- a/turbot/data/strings.yaml
+++ b/turbot/data/strings.yaml
@@ -66,7 +66,7 @@ turnippattern_pattern4: '> **Big Spike**: Prices fall until a small spike. Price
 uncollect_already: |-
   The following fossils were already marked as not collected:
   > $items
-uncollect_bad: |-
+fossil_bad: |-
   Did not recognize the following fossils:
   > $items
 uncollect_deleted: |-


### PR DESCRIPTION
Added feedback to let you know what fossils !fossilsearch was unable to find when handling a request.  Also, if no buy price was found by the !predict command, it only returned a string and no value for the attachment (None).  I added the attachment value so that it wouldn't fail.