### PR TITLE
Invalid fossil search tests

### DIFF
--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -16,7 +16,7 @@ import turbot
 
 CLIENT_TOKEN = "my-token"
 CLIENT_USER = "ADMIN"
-CLIENT_USER_ID = 0
+CLIENT_USER_ID = 82226367030108160
 
 AUTHORIZED_CHANNEL = "good channel"
 UNAUTHORIZED_CHANNEL = "bad channel"
@@ -37,12 +37,12 @@ class Member:
 
 
 ADMIN = Member(CLIENT_USER, CLIENT_USER_ID)
-FRIEND = Member("friend", 1)
-BUDDY = Member("buddy", 2)
-GUY = Member("guy", 3)
+FRIEND = Member("friend", 82169952898912256)
+BUDDY = Member("buddy", 82942320688758784)
+GUY = Member("guy", 82988021019836416)
 CHANNEL_MEMBERS = [FRIEND, BUDDY, GUY, ADMIN]
 
-PUNK = Member("punk", 4)
+PUNK = Member("punk", 119678027792646146)
 
 
 def someone():
@@ -817,7 +817,18 @@ class TestTurbot:
             "> a foot",
             None,
         )
-        assert lines(turbot.FOSSILS_FILE) == ["author,name\n", "1,ammonite\n"]
+        assert lines(turbot.FOSSILS_FILE) == ["author,name\n", f"{author.id},ammonite\n"]
+
+    async def test_on_message_uncollect_with_only_bad(self, client, lines):
+        channel = Channel("text", AUTHORIZED_CHANNEL)
+        author = someone()
+
+        fossils = "a foot, unicorn bits"
+        message = Message(author, channel, f"!uncollect {fossils}")
+        await client.on_message(message)
+        channel.sent.assert_called_with(
+            "Did not recognize the following fossils:\n> a foot, unicorn bits", None
+        )
 
     async def test_on_message_allfossils(self, client):
         channel = Channel("text", AUTHORIZED_CHANNEL)

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -597,23 +597,23 @@ class Turbot(discord.Client):
                 name = discord_user_from_id(channel, needer)
                 results[name].append(fossil)
 
-        if not results:
-            if len(invalid) > 0:
-                lines = [s("fossil_bad", items=", ".join(sorted(invalid)))]
-            else:
-                lines = [s("fossilsearch_noneed")]
+        if not results and not invalid:
+            return s("fossilsearch_noneed"), None
 
+        if not results and invalid:
+            lines = [s("fossil_bad", items=", ".join(sorted(invalid)))]
+            if valid:
+                lines.append(
+                    s("fossilsearch_row", name="No one", fossils=", ".join(sorted(valid)))
+                )
             return "\n".join(lines), None
 
         lines = [s("fossilsearch_header")]
         for name, needed in results.items():
             need_list = fossils = ", ".join(sorted(needed))
             lines.append(s("fossilsearch_row", name=name, fossils=need_list))
-
-        if len(invalid) > 0:
-            lines.append(" ")
+        if invalid:
             lines.append(s("fossil_bad", items=", ".join(sorted(invalid))))
-
         return "\n".join(lines), None
 
     def allfossils_command(self, channel, author, params):

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -588,15 +588,11 @@ class Turbot(discord.Client):
         invalid = items - valid
 
         fossils = load_fossils()
-        # I think we should still show if the searcher needs the fossil being
-        # searched for, just in case they missed it.
-        # theirs = fossils[fossils.author != author.id]
-        theirs = fossils
-        them = theirs.author.unique()
+        users = fossils.author.unique()
         results = defaultdict(list)
         for fossil in valid:
-            havers = theirs[theirs.name == fossil].author.unique()
-            needers = np.setdiff1d(them, havers).tolist()
+            havers = fossils[fossils.name == fossil].author.unique()
+            needers = np.setdiff1d(users, havers).tolist()
             for needer in needers:
                 name = discord_user_from_id(channel, needer)
                 results[name].append(fossil)

--- a/turbot/data/strings.yaml
+++ b/turbot/data/strings.yaml
@@ -8,6 +8,8 @@ buy: Logged buying price of $price for user $name.
 buy_no_params: Please include buying price after command name.
 buy_nonnumeric_price: Buying price must be a number.
 buy_nonpositive_price: Buying price must be greater than zero.
+cant_find_buy: There is no recent buy price for $name.
+cant_find_user: Can not find the user named $name in this channel.
 clear: '**Cleared history for $name.**'
 collect_bad: |-
   Did not recognize the following fossils:
@@ -23,6 +25,9 @@ collectedfossils: |-
   __**$count Fossils donated by $name**__
   >>> $items
 did_you_mean: 'Did you mean: $possible?'
+fossil_bad: |-
+  Did not recognize the following fossils:
+  > $items
 fossilcount_invalid: '> $name'
 fossilcount_invalid_header: __**Did not recognize the following names**__
 fossilcount_no_params: Please provide at least one user name to search for a fossil count.
@@ -46,6 +51,7 @@ listfossils: |-
 lookup: $user_id
 lookup_no_params: Please provide the name of a user to lookup.
 oops: '**Deleting last logged price for $name.**'
+predict: '$name''s turnip prediction link: $url'
 reset: '**Resetting data for a new week!**'
 sell_higher_price: Logged selling price of $price for user $name. (Higher than last selling price of $last_price bells)
 sell_lower_price: Logged selling price of $price for user $name. (Lower than last selling price of $last_price bells)
@@ -66,13 +72,7 @@ turnippattern_pattern4: '> **Big Spike**: Prices fall until a small spike. Price
 uncollect_already: |-
   The following fossils were already marked as not collected:
   > $items
-fossil_bad: |-
-  Did not recognize the following fossils:
-  > $items
 uncollect_deleted: |-
   Unmarked the following fossils as collected:
   > $items
 uncollect_no_params: Please provide the name of a fossil to mark as uncollected.
-cant_find_user: Can not find the user named $name in this channel.
-cant_find_buy: There is no recent buy price for $name.
-predict: "$name's turnip prediction link: $url"


### PR DESCRIPTION
**addc854363aaec3e14694b416b18aaaf5c92a667 Delete theirs concern from fossilsearch**

I agree, a couple users already tried to use it this way and were
surprised when it didn't work. We can just get rid of the `theirs`
variable here and rename things so the better represent the data they
contain.

**3756b646a9595d0f4b3e67cdf7cc7aef59eaa2e9 More information from fossilsearch response**

When there's a combination of no fossils that are needed plus a couple
that are invalid you would only get the list of invalid fossils but no
indication that the other fossils were not needed.

I changed the code a bit so that you get both a list of things that
aren't needed and the list of things that were invalid.

Also note that in Python you can always do `if some_list` to check if
the list is empty. Less typing and it's more pythonic apparently.

**70dc46504b1d99ceea2cf4fb28c975d02c81ae19 Sort the strings data**

Forgot to sort this whenever I added the `predict ` strings. I had been
trying to keep them sorted all the time just so diffs are consistent.
Maybe I can add a git hook to do this... :thinking:

**c77acea9117645b45bd3b8a1bb62f9bbf2b2ccab Adds tests cases for fossilsearch**

- Combination of fossils no one needs and some invalid ones.
- Combination of some fossils people need, don't need, and invalid ones.
- List of only invalid ones.

**1cb5997393000cba746fff4adc004484fba8a4c3 Adds test case for uncollect**

Added a test case to catch when someone tries to uncollect with a list
containing only invalid fossils. I also updated the userids of the
test data to be something a little closer to real data to make the
tests a bit stronger.