### PR TITLE
Adds search to fish command

### DIFF
--- a/scripts/update_fish_data.py
+++ b/scripts/update_fish_data.py
@@ -13,8 +13,8 @@ tree = BeautifulSoup(page.content, "lxml")
 
 
 class Hemisphere(Enum):
-    Northern = 1
-    Southern = 2
+    NORTHERN = 1
+    SOUTHERN = 2
 
 
 def clean(item):
@@ -31,7 +31,8 @@ def ingest(writer, hemisphere):
     for row in range(1, len(tab_data)):
         data = [clean(i) for i in tab_data[row]]
         if data:
-            corrected = [hemisphere.name, data[0], *[d.lower() for d in data[2:]]]
+            # lowercase all data and strip out the image column (2nd column)
+            corrected = [d.lower() for d in [hemisphere.name, data[0], *data[2:]]]
             writer.writerow(corrected)
 
 
@@ -59,5 +60,5 @@ with open(Path("turbot") / "data" / "fish.csv", "w", newline="") as out:
             "dec",
         ]
     )
-    ingest(writer, Hemisphere.Northern)
-    ingest(writer, Hemisphere.Southern)
+    ingest(writer, Hemisphere.NORTHERN)
+    ingest(writer, Hemisphere.SOUTHERN)

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -1080,7 +1080,7 @@ class TestTurbot:
         with open(client.users_file) as f:
             assert f.readlines() == [
                 "author,hemisphere\n",
-                f"{author.id},Southern\n",
+                f"{author.id},southern\n",
             ]
 
         message = Message(author, channel, f"!hemisphere NoRthErn")
@@ -1091,7 +1091,7 @@ class TestTurbot:
         with open(client.users_file) as f:
             assert f.readlines() == [
                 "author,hemisphere\n",
-                f"{author.id},Northern\n",
+                f"{author.id},northern\n",
             ]
 
     async def test_on_message_fish_no_hemisphere(self, client):
@@ -1102,6 +1102,57 @@ class TestTurbot:
         await client.on_message(message)
         channel.sent.assert_called_with(
             f"Please enter your hemisphere choice first using the !hemisphere command.",
+            None,
+        )
+
+    async def test_on_message_fish_none_found(self, client):
+        channel = Channel("text", AUTHORIZED_CHANNEL)
+        author = someone()
+
+        # give our author a hemisphere first
+        message = Message(author, channel, f"!hemisphere northern")
+        await client.on_message(message)
+
+        message = Message(author, channel, f"!fish Blinky")
+        await client.on_message(message)
+        channel.sent.assert_called_with(
+            f'Did not find any fish searching for "Blinky".', None
+        )
+
+    async def test_on_message_fish_search_query(self, client):
+        channel = Channel("text", AUTHORIZED_CHANNEL)
+        author = someone()
+
+        # give our author a hemisphere first
+        message = Message(author, channel, f"!hemisphere northern")
+        await client.on_message(message)
+
+        message = Message(author, channel, f"!fish ch")
+        await client.on_message(message)
+        channel.sent.assert_called_with(
+            "> **Anchovy** with shadow size 2 is available 4 am - 9 pm at sea (sells for 200 bells) during Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec \n"  # noqa: E501
+            "> **Char** with shadow size 3 is available 4 pm - 9 am at river (clifftop)  pond (sells for 3800 bells) during Mar, Apr, May, Jun, Sep, Oct, Nov \n"  # noqa: E501
+            "> **Cherry salmon** with shadow size 3 is available 4 pm - 9 am at river (clifftop) (sells for 800 bells) during Mar, Apr, May, Jun, Sep, Oct, Nov \n"  # noqa: E501
+            "> **Loach** with shadow size 2 is available all day at river (sells for 400 bells) during Mar, Apr, May \n"  # noqa: E501
+            "> **Pale chub** with shadow size 1 is available 9 am - 4 pm at river (sells for 200 bells) during Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec \n"  # noqa: E501
+            "> **Ranchu goldfish** with shadow size 2 is available 9 am - 4 pm at pond (sells for 4500 bells) during Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec ",  # noqa: E501
+            None,
+        )
+
+    async def test_on_message_fish_search_leaving(self, client):
+        channel = Channel("text", AUTHORIZED_CHANNEL)
+        author = someone()
+
+        # give our author a hemisphere first
+        message = Message(author, channel, f"!hemisphere northern")
+        await client.on_message(message)
+
+        message = Message(author, channel, f"!fish leaving")
+        await client.on_message(message)
+        channel.sent.assert_called_with(
+            "> **Blue marlin** with shadow size 6 is available all day at pier (sells for 10000 bells) during Jan, Feb, Mar, Apr, Jul, Aug, Sep, Nov, Dec **GONE NEXT MONTH!**\n"  # noqa: E501
+            "> **Dab** with shadow size 3 is available all day at sea (sells for 300 bells) during Jan, Feb, Mar, Apr, Oct, Nov, Dec **GONE NEXT MONTH!**\n"  # noqa: E501
+            "> **Tuna** with shadow size 6 is available all day at pier (sells for 7000 bells) during Jan, Feb, Mar, Apr, Nov, Dec **GONE NEXT MONTH!**",  # noqa: E501
             None,
         )
 
@@ -1120,51 +1171,51 @@ class TestTurbot:
         call = calls.pop()
         response, attachment = call[0][0], call[0][1]
         assert response == (
-            "> **Pale chub** is available 9 am - 4 pm at river (sells for 200 bells) \n"
+            "> **Oarfish** is available all day at sea (sells for 9000 bells) \n"  # noqa: E501
+            "> **Olive flounder** is available all day at sea (sells for 800 bells) \n"  # noqa: E501
+            "> **Pale chub** is available 9 am - 4 pm at river (sells for 200 bells) \n"  # noqa: E501
             "> **Pop-eyed goldfish** is available 9 am - 4 pm at pond (sells for 1300 bells) \n"  # noqa: E501
             "> **Ranchu goldfish** is available 9 am - 4 pm at pond (sells for 4500 bells) \n"  # noqa: E501
-            "> **Red snapper** is available all day at sea (sells for 3000 bells) \n"
-            "> **Sea bass** is available all day at sea (sells for 400 bells) \n"
-            "> **Sea horse** is available all day at sea (sells for 1100 bells) \n"
-            "> **Snapping Turtle** is available 9 pm - 4 am at river (sells for 5000 bells) \n"  # noqa: E501
-            "> **Squid** is available all day at sea (sells for 500 bells) \n"
-            "> **Surgeonfish** is available all day at sea (sells for 1000 bells) \n"
-            "> **Tadpole** is available all day at pond (sells for 100 bells) \n"
+            "> **Red snapper** is available all day at sea (sells for 3000 bells) \n"  # noqa: E501
+            "> **Sea bass** is available all day at sea (sells for 400 bells) \n"  # noqa: E501
+            "> **Sea horse** is available all day at sea (sells for 1100 bells) _New this month_\n"  # noqa: E501
+            "> **Snapping turtle** is available 9 pm - 4 am at river (sells for 5000 bells) _New this month_\n"  # noqa: E501
+            "> **Squid** is available all day at sea (sells for 500 bells) \n"  # noqa: E501
+            "> **Surgeonfish** is available all day at sea (sells for 1000 bells) _New this month_\n"  # noqa: E501
+            "> **Tadpole** is available all day at pond (sells for 100 bells) \n"  # noqa: E501
             "> **Tuna** is available all day at pier (sells for 7000 bells) **GONE NEXT MONTH!**\n"  # noqa: E501
-            "> **Zebra turkeyfish** is available all day at sea (sells for 500 bells) "
+            "> **Zebra turkeyfish** is available all day at sea (sells for 500 bells) _New this month_"  # noqa: E501
         )
         assert attachment is None
 
         call = calls.pop()
         response, attachment = call[0][0], call[0][1]
         assert response == (
-            "> **Anchovy** is available 4 am - 9 pm at sea (sells for 200 bells) \n"
-            "> **Barred knifejaw** is available all day at sea (sells for 5000 bells) \n"
-            "> **Barreleye** is available 9 pm - 4 am at sea (sells for 15000 bells) \n"
-            "> **Black bass** is available all day at river (sells for 400 bells) \n"
+            "> **Anchovy** is available 4 am - 9 pm at sea (sells for 200 bells) \n"  # noqa: E501
+            "> **Barred knifejaw** is available all day at sea (sells for 5000 bells) \n"  # noqa: E501
+            "> **Barreleye** is available 9 pm - 4 am at sea (sells for 15000 bells) \n"  # noqa: E501
+            "> **Black bass** is available all day at river (sells for 400 bells) \n"  # noqa: E501
             "> **Blue marlin** is available all day at pier (sells for 10000 bells) **GONE NEXT MONTH!**\n"  # noqa: E501
-            "> **Bluegill** is available 9 am - 4 pm at river (sells for 180 bells) \n"
-            "> **Butterfly fish** is available all day at sea (sells for 1000 bells) \n"
-            "> **Carp** is available all day at pond (sells for 300 bells) \n"
+            "> **Bluegill** is available 9 am - 4 pm at river (sells for 180 bells) \n"  # noqa: E501
+            "> **Butterfly fish** is available all day at sea (sells for 1000 bells) _New this month_\n"  # noqa: E501
+            "> **Carp** is available all day at pond (sells for 300 bells) \n"  # noqa: E501
             "> **Char** is available 4 pm - 9 am at river (clifftop)  pond (sells for 3800 bells) \n"  # noqa: E501
             "> **Cherry salmon** is available 4 pm - 9 am at river (clifftop) (sells for 800 bells) \n"  # noqa: E501
-            "> **Clown fish** is available all day at sea (sells for 650 bells) \n"
+            "> **Clown fish** is available all day at sea (sells for 650 bells) _New this month_\n"  # noqa: E501
             "> **Coelacanth** is available all day at sea (while raining) (sells for 15000 bells) \n"  # noqa: E501
-            "> **Crawfish** is available all day at pond (sells for 200 bells) \n"
-            "> **Crucian carp** is available all day at river (sells for 160 bells) \n"
+            "> **Crawfish** is available all day at pond (sells for 200 bells) _New this month_\n"  # noqa: E501
+            "> **Crucian carp** is available all day at river (sells for 160 bells) \n"  # noqa: E501
             "> **Dab** is available all day at sea (sells for 300 bells) **GONE NEXT MONTH!**\n"  # noqa: E501
-            "> **Dace** is available 4 pm - 9 am at river (sells for 240 bells) \n"
+            "> **Dace** is available 4 pm - 9 am at river (sells for 240 bells) \n"  # noqa: E501
             "> **Freshwater goby** is available 4 pm - 9 am at river (sells for 400 bells) \n"  # noqa: E501
             "> **Golden trout** is available 4 pm - 9 am at river (clifftop) (sells for 15000 bells) \n"  # noqa: E501
-            "> **Goldfish** is available all day at pond (sells for 1300 bells) \n"
-            "> **Guppy** is available 9 am - 4 pm at river (sells for 1300 bells) \n"
-            "> **Horse mackerel** is available all day at sea (sells for 150 bells) \n"
-            "> **Killifish** is available all day at pond (sells for 300 bells) \n"
-            "> **Koi** is available 4 pm - 9 am at pond (sells for 4000 bells) \n"
-            "> **Loach** is available all day at river (sells for 400 bells) \n"
-            "> **Neon tetra** is available 9 am - 4 pm at river (sells for 500 bells) \n"
-            "> **Oarfish** is available all day at sea (sells for 9000 bells) \n"
-            "> **Olive flounder** is available all day at sea (sells for 800 bells) "
+            "> **Goldfish** is available all day at pond (sells for 1300 bells) \n"  # noqa: E501
+            "> **Guppy** is available 9 am - 4 pm at river (sells for 1300 bells) _New this month_\n"  # noqa: E501
+            "> **Horse mackerel** is available all day at sea (sells for 150 bells) \n"  # noqa: E501
+            "> **Killifish** is available all day at pond (sells for 300 bells) _New this month_\n"  # noqa: E501
+            "> **Koi** is available 4 pm - 9 am at pond (sells for 4000 bells) \n"  # noqa: E501
+            "> **Loach** is available all day at river (sells for 400 bells) \n"  # noqa: E501
+            "> **Neon tetra** is available 9 am - 4 pm at river (sells for 500 bells) _New this month_"  # noqa: E501
         )
         assert attachment is None
 

--- a/turbot/data/fish.csv
+++ b/turbot/data/fish.csv
@@ -1,161 +1,161 @@
 hemisphere,name,price,location,shadow,time,jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec
-Northern,Bitterling,900,river,1,all day,1,1,1,0,0,0,0,0,0,0,1,1
-Northern,Pale chub,200,river,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Crucian carp,160,river,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Dace,240,river,3,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Carp,300,pond,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Koi,4000,pond,4,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Goldfish,1300,pond,1,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Pop-eyed goldfish,1300,pond,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Ranchu goldfish,4500,pond,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Killifish,300,pond,1,all day,0,0,0,1,1,1,1,1,0,0,0,0
-Northern,Crawfish,200,pond,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Northern,Soft-shelled turtle,3750,river,4,4 pm - 9 am,0,0,0,0,0,0,0,1,1,0,0,0
-Northern,Snapping Turtle,5000,river,4,9 pm - 4 am,0,0,0,1,1,1,1,1,1,1,0,0
-Northern,Tadpole,100,pond,1,all day,0,0,1,1,1,1,1,0,0,0,0,0
-Northern,Frog,120,pond,2,all day,0,0,0,0,1,1,1,1,0,0,0,0
-Northern,Freshwater goby,400,river,2,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Loach,400,river,2,all day,0,0,1,1,1,0,0,0,0,0,0,0
-Northern,Catfish,800,pond,4,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Giant snakehead,5500,pond,4,9 am - 4 pm,0,0,0,0,0,1,1,1,0,0,0,0
-Northern,Bluegill,180,river,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Yellow perch,300,river,3,all day,1,1,1,0,0,0,0,0,0,1,1,1
-Northern,Black bass,400,river,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Tilapia,800,river,3,all day,0,0,0,0,0,1,1,1,1,1,0,0
-Northern,Pike,1800,river,5,all day,0,0,0,0,0,0,0,0,1,1,1,1
-Northern,Pond smelt,500,river,2,all day,1,1,0,0,0,0,0,0,0,0,0,1
-Northern,Sweetfish,900,river,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
-Northern,Cherry salmon,800,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
-Northern,Char,3800,river (clifftop)  pond,3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
-Northern,Golden trout,15000,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,0,0,0,1,1,1,0
-Northern,Stringfish,15000,river (clifftop),5,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,0,1
-Northern,Salmon,700,river (mouth),4,all day,0,0,0,0,0,0,0,0,1,0,0,0
-Northern,King salmon,1800,river (mouth),6,all day,0,0,0,0,0,0,0,0,1,0,0,0
-Northern,Mitten crab,2000,river,2,4 pm - 9 am,0,0,0,0,0,0,0,0,1,1,1,0
-Northern,Guppy,1300,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
-Northern,Nibble fish,1500,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,0,0,0
-Northern,Angelfish,3000,river,2,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Betta,2500,river,2,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Neon tetra,500,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
-Northern,Rainbowfish,800,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Piranha,2500,river,2,9 am - 4 pm & 9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Arowana,10000,river,4,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Dorado,15000,river,5,4 am - 9 pm,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Gar,6000,pond,5,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Arapaima,10000,river,6,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Saddled bichir,4000,river,4,9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Sturgeon,10000,river (mouth),6,all day,1,1,1,0,0,0,0,0,1,1,1,1
-Northern,Sea butterfly,1000,sea,1,all day,1,1,1,0,0,0,0,0,0,0,0,1
-Northern,Sea horse,1100,sea,1,all day,0,0,0,1,1,1,1,1,1,1,1,0
-Northern,Clown fish,650,sea,1,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Northern,Surgeonfish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Northern,Butterfly fish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Northern,Napoleonfish,10000,sea,6,4 am - 9 pm,0,0,0,0,0,0,1,1,0,0,0,0
-Northern,Zebra turkeyfish,500,sea,3,all day,0,0,0,1,1,1,1,1,1,1,1,0
-Northern,Blowfish,5000,sea,3,9 pm - 4 am,1,1,0,0,0,0,0,0,0,0,1,1
-Northern,Puffer fish,250,sea,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
-Northern,Anchovy,200,sea,2,4 am - 9 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Horse mackerel,150,sea,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Barred knifejaw,5000,sea,3,all day,0,0,1,1,1,1,1,1,1,1,1,0
-Northern,Sea bass,400,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Red snapper,3000,sea,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Dab,300,sea,3,all day,1,1,1,1,0,0,0,0,0,1,1,1
-Northern,Olive flounder,800,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Squid,500,sea,3,all day,1,1,1,1,1,1,1,1,0,0,0,1
-Northern,Moray eel,2000,sea,narrow,all day,0,0,0,0,0,0,0,1,1,1,0,0
-Northern,Ribbon eel,600,sea,narrow,all day,0,0,0,0,0,1,1,1,1,1,0,0
-Northern,Tuna,7000,pier,6,all day,1,1,1,1,0,0,0,0,0,0,1,1
-Northern,Blue marlin,10000,pier,6,all day,1,1,1,1,0,0,1,1,1,0,1,1
-Northern,Giant trevally,4500,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Mahi-mahi,6000,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
-Northern,Ocean sunfish,4000,sea,6 (fin),4 am - 9 pm,0,0,0,0,0,0,1,1,1,0,0,0
-Northern,Ray,3000,sea,5,4 am - 9 pm,0,0,0,0,0,0,0,1,1,1,1,0
-Northern,Saw shark,12000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Hammerhead shark,8000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Great white shark,15000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Whale shark,13000,sea,6 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Suckerfish,1500,sea,4 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
-Northern,Football fish,2500,sea,4,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,1,1
-Northern,Oarfish,9000,sea,6,all day,1,1,1,1,1,0,0,0,0,0,0,1
-Northern,Barreleye,15000,sea,2,9 pm - 4 am,1,1,1,1,1,1,1,1,1,1,1,1
-Northern,Coelacanth,15000,sea (while raining),6,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Bitterling,900,river,1,all day,1,1,1,0,0,0,0,0,0,0,1,1
-Southern,Pale chub,200,river,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Crucian carp,160,river,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Dace,240,river,3,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Carp,300,pond,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Koi,4000,pond,4,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Goldfish,1300,pond,1,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Pop-eyed goldfish,1300,pond,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Ranchu goldfish,4500,pond,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Killifish,300,pond,1,all day,0,0,0,1,1,1,1,1,0,0,0,0
-Southern,Crawfish,200,pond,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Southern,Soft-shelled turtle,3750,river,4,4 pm - 9 am,0,0,0,0,0,0,0,1,1,0,0,0
-Southern,Snapping Turtle,5000,river,4,9 pm - 4 am,0,0,0,1,1,1,1,1,1,1,0,0
-Southern,Tadpole,100,pond,1,all day,0,0,1,1,1,1,1,0,0,0,0,0
-Southern,Frog,120,pond,2,all day,0,0,0,0,1,1,1,1,0,0,0,0
-Southern,Freshwater goby,400,river,2,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Loach,400,river,2,all day,0,0,1,1,1,0,0,0,0,0,0,0
-Southern,Catfish,800,pond,4,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Giant snakehead,5500,pond,4,9 am - 4 pm,0,0,0,0,0,1,1,1,0,0,0,0
-Southern,Bluegill,180,river,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Yellow perch,300,river,3,all day,1,1,1,0,0,0,0,0,0,1,1,1
-Southern,Black bass,400,river,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Tilapia,800,river,3,all day,0,0,0,0,0,1,1,1,1,1,0,0
-Southern,Pike,1800,river,5,all day,0,0,0,0,0,0,0,0,1,1,1,1
-Southern,Pond smelt,500,river,2,all day,1,1,0,0,0,0,0,0,0,0,0,1
-Southern,Sweetfish,900,river,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
-Southern,Cherry salmon,800,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
-Southern,Char,3800,river (clifftop)  pond,3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
-Southern,Golden trout,15000,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,0,0,0,1,1,1,0
-Southern,Stringfish,15000,river (clifftop),5,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,0,1
-Southern,Salmon,700,river (mouth),4,all day,0,0,0,0,0,0,0,0,1,0,0,0
-Southern,King salmon,1800,river (mouth),6,all day,0,0,0,0,0,0,0,0,1,0,0,0
-Southern,Mitten crab,2000,river,2,4 pm - 9 am,0,0,0,0,0,0,0,0,1,1,1,0
-Southern,Guppy,1300,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
-Southern,Nibble fish,1500,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,0,0,0
-Southern,Angelfish,3000,river,2,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Betta,2500,river,2,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Neon tetra,500,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
-Southern,Rainbowfish,800,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Piranha,2500,river,2,9 am - 4 pm & 9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Arowana,10000,river,4,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Dorado,15000,river,5,4 am - 9 pm,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Gar,6000,pond,5,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Arapaima,10000,river,6,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Saddled bichir,4000,river,4,9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Sturgeon,10000,river (mouth),6,all day,1,1,1,0,0,0,0,0,1,1,1,1
-Southern,Sea butterfly,1000,sea,1,all day,1,1,1,0,0,0,0,0,0,0,0,1
-Southern,Sea horse,1100,sea,1,all day,0,0,0,1,1,1,1,1,1,1,1,0
-Southern,Clown fish,650,sea,1,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Southern,Surgeonfish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Southern,Butterfly fish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
-Southern,Napoleonfish,10000,sea,6,4 am - 9 pm,0,0,0,0,0,0,1,1,0,0,0,0
-Southern,Zebra turkeyfish,500,sea,3,all day,0,0,0,1,1,1,1,1,1,1,1,0
-Southern,Blowfish,5000,sea,3,9 pm - 4 am,1,1,0,0,0,0,0,0,0,0,1,1
-Southern,Puffer fish,250,sea,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
-Southern,Anchovy,200,sea,2,4 am - 9 pm,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Horse mackerel,150,sea,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Barred knifejaw,5000,sea,3,all day,0,0,1,1,1,1,1,1,1,1,1,0
-Southern,Sea bass,400,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Red snapper,3000,sea,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Dab,300,sea,3,all day,1,1,1,1,0,0,0,0,0,1,1,1
-Southern,Olive flounder,800,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Squid,500,sea,3,all day,1,1,1,1,1,1,1,1,0,0,0,1
-Southern,Moray eel,2000,sea,narrow,all day,0,0,0,0,0,0,0,1,1,1,0,0
-Southern,Ribbon eel,600,sea,narrow,all day,0,0,0,0,0,1,1,1,1,1,0,0
-Southern,Tuna,7000,pier,6,all day,1,1,1,1,0,0,0,0,0,0,1,1
-Southern,Blue marlin,10000,pier,6,all day,1,1,1,1,0,0,1,1,1,0,1,1
-Southern,Giant trevally,4500,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Mahi-mahi,6000,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
-Southern,Ocean sunfish,4000,sea,6 (fin),4 am - 9 pm,0,0,0,0,0,0,1,1,1,0,0,0
-Southern,Ray,3000,sea,5,4 am - 9 pm,0,0,0,0,0,0,0,1,1,1,1,0
-Southern,Saw shark,12000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Hammerhead shark,8000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Great white shark,15000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Whale shark,13000,sea,6 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Suckerfish,1500,sea,4 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
-Southern,Football fish,2500,sea,4,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,1,1
-Southern,Oarfish,9000,sea,6,all day,1,1,1,1,1,0,0,0,0,0,0,1
-Southern,Barreleye,15000,sea,2,9 pm - 4 am,1,1,1,1,1,1,1,1,1,1,1,1
-Southern,Coelacanth,15000,sea (while raining),6,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,bitterling,900,river,1,all day,1,1,1,0,0,0,0,0,0,0,1,1
+northern,pale chub,200,river,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+northern,crucian carp,160,river,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,dace,240,river,3,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+northern,carp,300,pond,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,koi,4000,pond,4,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+northern,goldfish,1300,pond,1,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,pop-eyed goldfish,1300,pond,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+northern,ranchu goldfish,4500,pond,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+northern,killifish,300,pond,1,all day,0,0,0,1,1,1,1,1,0,0,0,0
+northern,crawfish,200,pond,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+northern,soft-shelled turtle,3750,river,4,4 pm - 9 am,0,0,0,0,0,0,0,1,1,0,0,0
+northern,snapping turtle,5000,river,4,9 pm - 4 am,0,0,0,1,1,1,1,1,1,1,0,0
+northern,tadpole,100,pond,1,all day,0,0,1,1,1,1,1,0,0,0,0,0
+northern,frog,120,pond,2,all day,0,0,0,0,1,1,1,1,0,0,0,0
+northern,freshwater goby,400,river,2,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+northern,loach,400,river,2,all day,0,0,1,1,1,0,0,0,0,0,0,0
+northern,catfish,800,pond,4,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
+northern,giant snakehead,5500,pond,4,9 am - 4 pm,0,0,0,0,0,1,1,1,0,0,0,0
+northern,bluegill,180,river,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+northern,yellow perch,300,river,3,all day,1,1,1,0,0,0,0,0,0,1,1,1
+northern,black bass,400,river,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,tilapia,800,river,3,all day,0,0,0,0,0,1,1,1,1,1,0,0
+northern,pike,1800,river,5,all day,0,0,0,0,0,0,0,0,1,1,1,1
+northern,pond smelt,500,river,2,all day,1,1,0,0,0,0,0,0,0,0,0,1
+northern,sweetfish,900,river,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
+northern,cherry salmon,800,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
+northern,char,3800,river (clifftop)  pond,3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
+northern,golden trout,15000,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,0,0,0,1,1,1,0
+northern,stringfish,15000,river (clifftop),5,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,0,1
+northern,salmon,700,river (mouth),4,all day,0,0,0,0,0,0,0,0,1,0,0,0
+northern,king salmon,1800,river (mouth),6,all day,0,0,0,0,0,0,0,0,1,0,0,0
+northern,mitten crab,2000,river,2,4 pm - 9 am,0,0,0,0,0,0,0,0,1,1,1,0
+northern,guppy,1300,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
+northern,nibble fish,1500,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,0,0,0
+northern,angelfish,3000,river,2,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
+northern,betta,2500,river,2,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
+northern,neon tetra,500,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
+northern,rainbowfish,800,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
+northern,piranha,2500,river,2,9 am - 4 pm & 9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,arowana,10000,river,4,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,dorado,15000,river,5,4 am - 9 pm,0,0,0,0,0,1,1,1,1,0,0,0
+northern,gar,6000,pond,5,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,arapaima,10000,river,6,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,saddled bichir,4000,river,4,9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,sturgeon,10000,river (mouth),6,all day,1,1,1,0,0,0,0,0,1,1,1,1
+northern,sea butterfly,1000,sea,1,all day,1,1,1,0,0,0,0,0,0,0,0,1
+northern,sea horse,1100,sea,1,all day,0,0,0,1,1,1,1,1,1,1,1,0
+northern,clown fish,650,sea,1,all day,0,0,0,1,1,1,1,1,1,0,0,0
+northern,surgeonfish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+northern,butterfly fish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+northern,napoleonfish,10000,sea,6,4 am - 9 pm,0,0,0,0,0,0,1,1,0,0,0,0
+northern,zebra turkeyfish,500,sea,3,all day,0,0,0,1,1,1,1,1,1,1,1,0
+northern,blowfish,5000,sea,3,9 pm - 4 am,1,1,0,0,0,0,0,0,0,0,1,1
+northern,puffer fish,250,sea,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
+northern,anchovy,200,sea,2,4 am - 9 pm,1,1,1,1,1,1,1,1,1,1,1,1
+northern,horse mackerel,150,sea,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,barred knifejaw,5000,sea,3,all day,0,0,1,1,1,1,1,1,1,1,1,0
+northern,sea bass,400,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,red snapper,3000,sea,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,dab,300,sea,3,all day,1,1,1,1,0,0,0,0,0,1,1,1
+northern,olive flounder,800,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
+northern,squid,500,sea,3,all day,1,1,1,1,1,1,1,1,0,0,0,1
+northern,moray eel,2000,sea,narrow,all day,0,0,0,0,0,0,0,1,1,1,0,0
+northern,ribbon eel,600,sea,narrow,all day,0,0,0,0,0,1,1,1,1,1,0,0
+northern,tuna,7000,pier,6,all day,1,1,1,1,0,0,0,0,0,0,1,1
+northern,blue marlin,10000,pier,6,all day,1,1,1,1,0,0,1,1,1,0,1,1
+northern,giant trevally,4500,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
+northern,mahi-mahi,6000,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
+northern,ocean sunfish,4000,sea,6 (fin),4 am - 9 pm,0,0,0,0,0,0,1,1,1,0,0,0
+northern,ray,3000,sea,5,4 am - 9 pm,0,0,0,0,0,0,0,1,1,1,1,0
+northern,saw shark,12000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,hammerhead shark,8000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,great white shark,15000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+northern,whale shark,13000,sea,6 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
+northern,suckerfish,1500,sea,4 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
+northern,football fish,2500,sea,4,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,1,1
+northern,oarfish,9000,sea,6,all day,1,1,1,1,1,0,0,0,0,0,0,1
+northern,barreleye,15000,sea,2,9 pm - 4 am,1,1,1,1,1,1,1,1,1,1,1,1
+northern,coelacanth,15000,sea (while raining),6,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,bitterling,900,river,1,all day,1,1,1,0,0,0,0,0,0,0,1,1
+southern,pale chub,200,river,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+southern,crucian carp,160,river,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,dace,240,river,3,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+southern,carp,300,pond,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,koi,4000,pond,4,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+southern,goldfish,1300,pond,1,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,pop-eyed goldfish,1300,pond,1,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+southern,ranchu goldfish,4500,pond,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+southern,killifish,300,pond,1,all day,0,0,0,1,1,1,1,1,0,0,0,0
+southern,crawfish,200,pond,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+southern,soft-shelled turtle,3750,river,4,4 pm - 9 am,0,0,0,0,0,0,0,1,1,0,0,0
+southern,snapping turtle,5000,river,4,9 pm - 4 am,0,0,0,1,1,1,1,1,1,1,0,0
+southern,tadpole,100,pond,1,all day,0,0,1,1,1,1,1,0,0,0,0,0
+southern,frog,120,pond,2,all day,0,0,0,0,1,1,1,1,0,0,0,0
+southern,freshwater goby,400,river,2,4 pm - 9 am,1,1,1,1,1,1,1,1,1,1,1,1
+southern,loach,400,river,2,all day,0,0,1,1,1,0,0,0,0,0,0,0
+southern,catfish,800,pond,4,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
+southern,giant snakehead,5500,pond,4,9 am - 4 pm,0,0,0,0,0,1,1,1,0,0,0,0
+southern,bluegill,180,river,2,9 am - 4 pm,1,1,1,1,1,1,1,1,1,1,1,1
+southern,yellow perch,300,river,3,all day,1,1,1,0,0,0,0,0,0,1,1,1
+southern,black bass,400,river,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,tilapia,800,river,3,all day,0,0,0,0,0,1,1,1,1,1,0,0
+southern,pike,1800,river,5,all day,0,0,0,0,0,0,0,0,1,1,1,1
+southern,pond smelt,500,river,2,all day,1,1,0,0,0,0,0,0,0,0,0,1
+southern,sweetfish,900,river,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
+southern,cherry salmon,800,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
+southern,char,3800,river (clifftop)  pond,3,4 pm - 9 am,0,0,1,1,1,1,0,0,1,1,1,0
+southern,golden trout,15000,river (clifftop),3,4 pm - 9 am,0,0,1,1,1,0,0,0,1,1,1,0
+southern,stringfish,15000,river (clifftop),5,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,0,1
+southern,salmon,700,river (mouth),4,all day,0,0,0,0,0,0,0,0,1,0,0,0
+southern,king salmon,1800,river (mouth),6,all day,0,0,0,0,0,0,0,0,1,0,0,0
+southern,mitten crab,2000,river,2,4 pm - 9 am,0,0,0,0,0,0,0,0,1,1,1,0
+southern,guppy,1300,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
+southern,nibble fish,1500,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,0,0,0
+southern,angelfish,3000,river,2,4 pm - 9 am,0,0,0,0,1,1,1,1,1,1,0,0
+southern,betta,2500,river,2,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
+southern,neon tetra,500,river,1,9 am - 4 pm,0,0,0,1,1,1,1,1,1,1,1,0
+southern,rainbowfish,800,river,1,9 am - 4 pm,0,0,0,0,1,1,1,1,1,1,0,0
+southern,piranha,2500,river,2,9 am - 4 pm & 9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,arowana,10000,river,4,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,dorado,15000,river,5,4 am - 9 pm,0,0,0,0,0,1,1,1,1,0,0,0
+southern,gar,6000,pond,5,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,arapaima,10000,river,6,4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,saddled bichir,4000,river,4,9 pm - 4 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,sturgeon,10000,river (mouth),6,all day,1,1,1,0,0,0,0,0,1,1,1,1
+southern,sea butterfly,1000,sea,1,all day,1,1,1,0,0,0,0,0,0,0,0,1
+southern,sea horse,1100,sea,1,all day,0,0,0,1,1,1,1,1,1,1,1,0
+southern,clown fish,650,sea,1,all day,0,0,0,1,1,1,1,1,1,0,0,0
+southern,surgeonfish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+southern,butterfly fish,1000,sea,2,all day,0,0,0,1,1,1,1,1,1,0,0,0
+southern,napoleonfish,10000,sea,6,4 am - 9 pm,0,0,0,0,0,0,1,1,0,0,0,0
+southern,zebra turkeyfish,500,sea,3,all day,0,0,0,1,1,1,1,1,1,1,1,0
+southern,blowfish,5000,sea,3,9 pm - 4 am,1,1,0,0,0,0,0,0,0,0,1,1
+southern,puffer fish,250,sea,3,all day,0,0,0,0,0,0,1,1,1,0,0,0
+southern,anchovy,200,sea,2,4 am - 9 pm,1,1,1,1,1,1,1,1,1,1,1,1
+southern,horse mackerel,150,sea,2,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,barred knifejaw,5000,sea,3,all day,0,0,1,1,1,1,1,1,1,1,1,0
+southern,sea bass,400,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,red snapper,3000,sea,4,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,dab,300,sea,3,all day,1,1,1,1,0,0,0,0,0,1,1,1
+southern,olive flounder,800,sea,5,all day,1,1,1,1,1,1,1,1,1,1,1,1
+southern,squid,500,sea,3,all day,1,1,1,1,1,1,1,1,0,0,0,1
+southern,moray eel,2000,sea,narrow,all day,0,0,0,0,0,0,0,1,1,1,0,0
+southern,ribbon eel,600,sea,narrow,all day,0,0,0,0,0,1,1,1,1,1,0,0
+southern,tuna,7000,pier,6,all day,1,1,1,1,0,0,0,0,0,0,1,1
+southern,blue marlin,10000,pier,6,all day,1,1,1,1,0,0,1,1,1,0,1,1
+southern,giant trevally,4500,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
+southern,mahi-mahi,6000,pier,5,all day,0,0,0,0,1,1,1,1,1,1,0,0
+southern,ocean sunfish,4000,sea,6 (fin),4 am - 9 pm,0,0,0,0,0,0,1,1,1,0,0,0
+southern,ray,3000,sea,5,4 am - 9 pm,0,0,0,0,0,0,0,1,1,1,1,0
+southern,saw shark,12000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,hammerhead shark,8000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,great white shark,15000,sea,6 (fin),4 pm - 9 am,0,0,0,0,0,1,1,1,1,0,0,0
+southern,whale shark,13000,sea,6 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
+southern,suckerfish,1500,sea,4 (fin),all day,0,0,0,0,0,1,1,1,1,0,0,0
+southern,football fish,2500,sea,4,4 pm - 9 am,1,1,1,0,0,0,0,0,0,0,1,1
+southern,oarfish,9000,sea,6,all day,1,1,1,1,1,0,0,0,0,0,0,1
+southern,barreleye,15000,sea,2,9 pm - 4 am,1,1,1,1,1,1,1,1,1,1,1,1
+southern,coelacanth,15000,sea (while raining),6,all day,1,1,1,1,1,1,1,1,1,1,1,1

--- a/turbot/data/strings.yaml
+++ b/turbot/data/strings.yaml
@@ -26,7 +26,9 @@ collectedfossils: |-
   >>> $items
 did_you_mean: 'Did you mean: $possible?'
 fish: '> **$name** is available $time at $location (sells for $price bells) $alert'
+fish_detail: '> **$name** with shadow size $shadow is available $time at $location (sells for $price bells) during $months $alert'
 fish_no_hemisphere: Please enter your hemisphere choice first using the !hemisphere command.
+fish_none_found: Did not find any fish searching for "$search".
 fossil_bad: |-
   Did not recognize the following fossils:
   > $items


### PR DESCRIPTION
You can now search for fish with `!fish substring`. It'll find any fish with the given substring in their names. The results returned by a search give a little more details than the generic `!fish` command with no parameters.

You can also search for the special query `leaving` and it will look for fish that are not available next month.

Also I made all the data lowercase b/c it makes the code a lot easier. We can transform the data to capitalize it or whatever at display time. This better follows the best practice pattern of keeping things in their canonical form in the database and then transforming that data when displayed to the user.

> **IMPORTANT: We need to go into `db/users.csv` and make sure to lowercase everything in there after installing this change. Otherwise the fish command won't understand existing users' hemisphere choices!**

![Screen Shot 2020-04-20 at 1 36 14 PM](https://user-images.githubusercontent.com/1903876/79797467-2281ce80-830c-11ea-8db3-cf64963f8caf.png)
