### PR TITLE
Handle empty request

### DIFF
--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -236,6 +236,15 @@ class TestTurbot:
         await client.on_message(message)
         channel.sent.assert_not_called()
 
+    async def test_on_message_no_request(self, client, channel):
+        await client.on_message(MockMessage(someone(), channel, "!"))
+        await client.on_message(MockMessage(someone(), channel, "!!"))
+        await client.on_message(MockMessage(someone(), channel, "!!!"))
+        await client.on_message(MockMessage(someone(), channel, "!   "))
+        await client.on_message(MockMessage(someone(), channel, "!   !"))
+        await client.on_message(MockMessage(someone(), channel, " !   !"))
+        channel.sent.assert_not_called()
+
     async def test_on_message_ambiguous_request(self, client, channel):
         author = someone()
         message = MockMessage(author, channel, "!h")

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -366,6 +366,8 @@ class Turbot(discord.Client):
         """Process a command message."""
         tokens = message.content.split(" ")
         request, params = tokens[0].lstrip("!"), tokens[1:]
+        if not request:
+            return
         members = inspect.getmembers(self, predicate=inspect.ismethod)
         commands = [member[0] for member in members if member[0].endswith("_command")]
         matching = [command for command in commands if command.startswith(request)]

--- a/turbot/__init__.py
+++ b/turbot/__init__.py
@@ -110,18 +110,9 @@ def discord_user_id(channel, name):
     return getattr(discord_user_from_name(channel, name), "id", None)
 
 
-def is_turbot_admin(channel, user):
-    """Checks to see if user has the Turbot Admin role in this server"""
-
-    # Is there a way to go from User to Member to roles?
-    # member.roles
-    member = channel.guild.get_member(user.id)
-    if member:  # Since the user sent a message, they should be a member
-        for role in member.roles:
-            if str(role) == "Turbot Admin":
-                return True
-
-    return False
+def is_turbot_admin(user):
+    """Checks to see if user has the Turbot Admin role in this server."""
+    return any(role.name == "Turbot Admin" for role in user.roles)
 
 
 class Turbot(discord.Client):
@@ -513,12 +504,10 @@ class Turbot(discord.Client):
 
     def reset_command(self, channel, author, params):
         """
-        DO NOT USE UNLESS ASKED. Generates a final graph for use with !lastweek and
-        resets all data for all users.
+        Only Turbot Admin members can run this command. Generates a final graph for use
+        with !lastweek and resets all data for all users.
         """
-
-        # Only users with the Turbot Admin role can do a reset
-        if not is_turbot_admin(channel, author):
+        if not is_turbot_admin(author):
             return s("not_admin"), None
 
         self.generate_graph(channel, None, LASTWEEKCMD_FILE)


### PR DESCRIPTION
**Builds upon work from https://github.com/theastropath/turbot/pull/52**

Fixes the case where turbot was responding to things like just a single `!` in chat.