### PR TITLE
Rename build workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Turbot
+name: build
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pytest -k your_test_function --snapshot-update
 
 [black-badge]:      https://img.shields.io/badge/code%20style-black-000000.svg
 [black]:            https://github.com/psf/black
-[build-badge]:      https://github.com/theastropath/turbot/workflows/Turbot/badge.svg
+[build-badge]:      https://github.com/theastropath/turbot/workflows/build/badge.svg
 [build]:            https://github.com/theastropath/turbot/actions
 [codecov-badge]:    https://codecov.io/gh/theastropath/turbot/branch/master/graph/badge.svg
 [codecov]:          https://codecov.io/gh/theastropath/turbot


### PR DESCRIPTION
When I first named the workflow I didn't know the name would be the text in the badge here:

![Screen Shot 2020-04-25 at 10 03 37 PM](https://user-images.githubusercontent.com/1903876/80298390-a12da000-8740-11ea-842d-04313b0271c3.png)

Would make a lot more sense for that badge to say `build: passing` I think.