### PR TITLE
Adds user !info command

### DIFF
--- a/src/turbot/__init__.py
+++ b/src/turbot/__init__.py
@@ -1508,6 +1508,34 @@ class Turbot(discord.Client):
             None,
         )
 
+    def info_command(self, channel, author, params):
+        """
+        Gives you information on a user. | [user]
+        """
+        if len(params) < 1:
+            return s("info_no_params"), None
+
+        users = self.load_users()
+        for _, row in users.iterrows():
+            user_id = row["author"]
+            name = discord_user_name(channel, user_id)
+            if not name:
+                continue
+
+            if name.find(params[0]) != -1:
+                now = self.to_usertime(user_id, datetime.now(pytz.utc))
+                return (
+                    s(
+                        "info",
+                        hemisphere=self.get_user_hemisphere(user_id).title(),
+                        time=now.strftime("%I:%M %p %Z"),
+                        name=name,
+                    ),
+                    None,
+                )
+
+        return s("info_not_found"), None
+
 
 def get_token(token_file):  # pragma: no cover
     """Returns the discord token from the environment or your token config file."""

--- a/src/turbot/data/strings.yaml
+++ b/src/turbot/data/strings.yaml
@@ -103,6 +103,13 @@ hemisphere_no_params: Please provide the name of your hemisphere, northern or so
 history_buy: '> Can buy turnips from Daisy Mae for $price bells $timestamp'
 history_header: __**Historical info for $name**__
 history_sell: '> Can sell turnips to Timmy & Tommy for $price bells $timestamp'
+info: '__**$name**__
+
+  > Hemisphere: $hemisphere
+
+  > Current time: $time'
+info_no_params: Please provide a search term.
+info_not_found: No users found.
 lastweek: __**Historical Graph from Last Week**__
 lastweek_none: No graph from last week.
 listart_count: __**$count Pieces of art remaining for $name**__

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -1844,6 +1844,27 @@ class TestTurbot:
         assert subject(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) == ["Jan"]
         assert subject(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) == []
 
+    async def test_on_message_info(self, client, channel):
+        author = someone()
+        await client.on_message(MockMessage(author, channel, "!hemisphere northern"))
+        await client.on_message(
+            MockMessage(author, channel, "!timezone America/Los_Angeles")
+        )
+        await client.on_message(MockMessage(someone(), channel, f"!info {author.name}"))
+        assert channel.last_sent_response == (
+            f"__**{author}**__\n"
+            "> Hemisphere: Northern\n"
+            "> Current time: 04:00 PM PST"
+        )
+
+    async def test_on_message_info_not_found(self, client, channel):
+        await client.on_message(MockMessage(someone(), channel, f"!info {PUNK.name}"))
+        assert channel.last_sent_response == "No users found."
+
+    async def test_on_message_info_no_params(self, client, channel):
+        await client.on_message(MockMessage(someone(), channel, f"!info"))
+        assert channel.last_sent_response == "Please provide a search term."
+
 
 class TestFigures:
     @pytest.mark.mpl_image_compare


### PR DESCRIPTION
![Screen Shot 2020-04-29 at 4 37 52 PM](https://user-images.githubusercontent.com/1903876/80657171-c7508a00-8a37-11ea-923a-300997c8ab0c.png)

In the future we can add things to a user's info, for example:

- Island Name https://github.com/theastropath/turbot/issues/109
- Switch Friend Code https://github.com/theastropath/turbot/issues/108
- Island Rules https://github.com/theastropath/turbot/issues/100
- Wants https://github.com/theastropath/turbot/issues/110
- Sall/Catalog Items https://github.com/theastropath/turbot/issues/18
- Etc...