### PR TITLE
Transactional publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -eu
 
 usage() {
     echo "usage: ${0##*/} [minor|major|patch] [-h|--help]" 1>&2
@@ -54,4 +56,7 @@ git push origin master
 
 # publish the release; assumes you've set up non-interactive publishing by
 # previously having run: `poetry config pypi-token.pypi "YOUR-PYPI-TOKEN-GOES-HERE"`
-poetry publish -n
+if ! poetry publish -n; then
+    echo "error: publish command failed, see log for details" 1>&2
+    git reset --hard HEAD~1
+fi


### PR DESCRIPTION
If the publish command fails we need to roll back the commit so that the script is transactional. We also need to make absolutely sure that the -e and -u options are set correctly. It's safer to do this in a separate set command than rely on shell opts working properly (these have been known to be flaky in certain versions of bash for example).