### PR TITLE
Adds auto-reload dev option

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -265,6 +265,18 @@ tests = ["freezegun", "pytest", "pytest-cov"]
 
 [[package]]
 category = "main"
+description = "Integrated process monitor for developing and reloading daemons."
+name = "hupper"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.10.2"
+
+[package.extras]
+docs = ["watchdog", "sphinx", "pylons-sphinx-themes"]
+testing = ["watchdog", "pytest", "pytest-cov", "mock"]
+
+[[package]]
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -932,7 +944,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "2f3ac02625a1609f6685a0c098f69c2001c9c8b71bc3eb9a881cb32f0eb83732"
+content-hash = "4ac302be66b96ad45e52d30fc1c137689a6fdc5b5e99850c623d3b1e1aafc917"
 python-versions = '^3.7'
 
 [metadata.files]
@@ -1073,6 +1085,10 @@ freezegun = [
 humanize = [
     {file = "humanize-2.4.0-py3-none-any.whl", hash = "sha256:07dd1293bac6c77daa5ccdc22c0b41b2315bee0e339a9f035ba86a9f1a272002"},
     {file = "humanize-2.4.0.tar.gz", hash = "sha256:42ae7d54b398c01bd100847f6cb0fc9e381c21be8ad3f8e2929135e48dbff026"},
+]
+hupper = [
+    {file = "hupper-1.10.2-py2.py3-none-any.whl", hash = "sha256:5de835f3b58324af2a8a16f52270c4d1a3d1734c45eed94b77fd622aea737f29"},
+    {file = "hupper-1.10.2.tar.gz", hash = "sha256:3818f53dabc24da66f65cf4878c1c7a9b5df0c46b813e014abdd7c569eb9a02a"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dunamai = "^1.1.0"
 humanize = "^2.4.0"
 python-dateutil = "^2.8.1"
 turnips = {path = "vendor/turnips/turnips-0.6.4.dev6+gc6ce6a0.tar.gz", develop = false}
+hupper = "^1.10.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"

--- a/src/turbot/__init__.py
+++ b/src/turbot/__init__.py
@@ -17,6 +17,7 @@ from string import Template
 import click
 import discord
 import dunamai as _dunamai
+import hupper
 import matplotlib
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
@@ -1730,6 +1731,12 @@ def get_channels(channels_file):  # pragma: no cover
     help="read users preferences data from this file",
 )
 @click.version_option(version=__version__)
+@click.option(
+    "--dev",
+    default=False,
+    is_flag=True,
+    help="Development mode, automatically reload bot when source changes",
+)
 def main(
     log_level,
     verbose,
@@ -1740,11 +1747,16 @@ def main(
     art_file,
     fossils_file,
     users_file,
+    dev,
 ):  # pragma: no cover
     auth_channels = get_channels(auth_channels_file) + list(channel)
     if not auth_channels:
         print("error: you must provide at least one authorized channel", file=sys.stderr)
         sys.exit(1)
+
+    if dev:
+        reloader = hupper.start_reloader("turbot.main")
+        reloader.watch_files([ART_DATA_FILE, BUGS_DATA_FILE, FISH_DATA_FILE])
 
     # ensure transient application directories exist
     DB_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
Automatically reload the bot whenever the source code changes if you use the `--dev` option. Also picks up changes to data files if they change during runtime.