### PR TITLE
Cleans up commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ More usage help can be found by running `turbot --help`.
 Once you've connected the bot to your server, you can interact with it over
 Discord via the following commands in any of the authorized channels.
 
-- `!help` - Provides detailed help about all of the following commands
-- `!about` - Get information about Turbot
+- `!about`: Get information about Turbot
+- `!help`: Provides detailed help about all of the following commands
 
 ### 🤔 User Preferences
 
@@ -62,7 +62,8 @@ user's preferred timezone.
 
 These commands help users buy low and sell high in the stalk market.
 
-- `!bestsell`: Look for the best buy
+- `!bestbuy`: Look for the best buy
+- `!bestsell`: Look for the best sell
 - `!buy`: Save a buy price
 - `!clear`: Clear your price data
 - `!graph`: Graph price data
@@ -72,7 +73,6 @@ These commands help users buy low and sell high in the stalk market.
 - `!predict`: Predict your price data for the rest of the week
 - `!reset`: Reset all users' data
 - `!sell`: Save a sell price
-- `!turnippattern`: Determine your turnip price pattern for the week
 
 ### 🐟 Fish and Bugs
 

--- a/src/turbot/__init__.py
+++ b/src/turbot/__init__.py
@@ -212,6 +212,11 @@ def is_turbot_admin(channel, user_or_member):
     return any(role.name == "Turbot Admin" for role in member.roles) if member else False
 
 
+def command(f):
+    f.is_command = True
+    return f
+
+
 class Turbot(discord.Client):
     """Discord turnip bot"""
 
@@ -240,6 +245,14 @@ class Turbot(discord.Client):
         self._fossils_data = None  # do not use directly, load it from load_fossils()
         self._users_data = None  # do not use directly, load it from load_users()
         self._last_backup_filename = None
+
+        # build a list of commands supported by this bot by fetching @command methods
+        members = inspect.getmembers(self, predicate=inspect.ismethod)
+        self._commands = [
+            member[0]
+            for member in members
+            if hasattr(member[1], "is_command") and member[1].is_command
+        ]
 
     def run(self):  # pragma: no cover
         super().run(self.token)
@@ -596,6 +609,11 @@ class Turbot(discord.Client):
 
         yield remaining
 
+    @property
+    def commands(self):
+        """Returns a list of commands supported by this bot."""
+        return self._commands
+
     async def process(self, message):
         """Process a command message."""
         tokens = message.content.split(" ")
@@ -603,18 +621,15 @@ class Turbot(discord.Client):
         params = list(filter(None, params))  # ignore any empty string parameters
         if not request:
             return
-        members = inspect.getmembers(self, predicate=inspect.ismethod)
-        commands = [member[0] for member in members if member[0].endswith("_command")]
-        matching = [command for command in commands if command.startswith(request)]
+        matching = [command for command in self.commands if command.startswith(request)]
         if not matching:
             await message.channel.send(s("not_a_command", request=request), file=None)
             return
-        exact = f"{request}_command"
-        if len(matching) > 1 and exact not in matching:
-            possible = ", ".join(f"!{m.replace('_command', '')}" for m in matching)
+        if len(matching) > 1 and request not in matching:
+            possible = ", ".join(f"!{m}" for m in matching)
             await message.channel.send(s("did_you_mean", possible=possible), file=None)
         else:
-            command = exact if exact in matching else matching[0]
+            command = request if request in matching else matching[0]
             logging.debug("%s (author=%s, params=%s)", command, message.author, params)
             method = getattr(self, command)
             async with message.channel.typing():
@@ -661,10 +676,11 @@ class Turbot(discord.Client):
     # Bot Command Functions
     ##############################
 
-    # Any method of this class with a name that ends in _command is automatically
-    # detected as a bot command. These methods should have a signature like:
+    # Any method of this class with a name that is decorated by @command is detected as a
+    # bot command. These methods should have a signature like:
     #
-    #     def your_command(self, channel, author, params)
+    #     @command
+    #     def command_name(self, channel, author, params)
     #
     # - `channel` is the Discord channel where the command message was sent.
     # - `author` is the Discord author who sent the command.
@@ -692,7 +708,8 @@ class Turbot(discord.Client):
     #
     # A [parameter] is optional whereas a <parameter> is required.
 
-    def help_command(self, channel, author, params):
+    @command
+    def help(self, channel, author, params):
         """
         Shows this help screen.
         """
@@ -740,7 +757,8 @@ class Turbot(discord.Client):
         hour_offset = 13 if time_of_day == "evening" else 0
         return start + timedelta(days=day_offset, hours=hour_offset)
 
-    def sell_command(self, channel, author, params):
+    @command
+    def sell(self, channel, author, params):
         """
         Log the price that you can sell turnips for on your island.
         | <price> [day time]
@@ -777,7 +795,8 @@ class Turbot(discord.Client):
         )
         return s(key, price=price, name=author, last_price=last_price), None
 
-    def buy_command(self, channel, author, params):
+    @command
+    def buy(self, channel, author, params):
         """
         Log the price that you can buy turnips from Daisy Mae on your island.
         | <price> [day time]
@@ -803,7 +822,8 @@ class Turbot(discord.Client):
 
         return s("buy", price=price, name=author), None
 
-    def reset_command(self, channel, author, params):
+    @command
+    def reset(self, channel, author, params):
         """
         Only Turbot Admin members can run this command. Generates a final graph for use
         with !lastweek and resets all data for all users.
@@ -821,7 +841,8 @@ class Turbot(discord.Client):
         self.save_prices(prices)
         return s("reset"), None
 
-    def lastweek_command(self, channel, author, params):
+    @command
+    def lastweek(self, channel, author, params):
         """
         Displays the final graph from the last week before the data was reset.
         """
@@ -829,7 +850,8 @@ class Turbot(discord.Client):
             return s("lastweek_none"), None
         return s("lastweek"), discord.File(LASTWEEKCMD_FILE)
 
-    def graph_command(self, channel, author, params):
+    @command
+    def graph(self, channel, author, params):
         """
         Generates a graph of turnip prices for all users. If a user is specified, only
         graph that users prices. | [user]
@@ -848,43 +870,8 @@ class Turbot(discord.Client):
         self.generate_graph(channel, user, GRAPHCMD_FILE)
         return s("graph_user", name=user_name), discord.File(GRAPHCMD_FILE)
 
-    def turnippattern_command(self, channel, author, params):
-        """
-        Calculates the patterns you will see in your shop based on Daisy Mae's price
-        on your island and your Monday morning sell price. |
-        <Sunday Buy Price> <Monday Morning Sell Price>
-        """
-        if len(params) != 2:
-            return s("turnippattern_bad_params"), None
-
-        buyprice, mondayprice = params
-        if not buyprice.isnumeric() or not mondayprice.isnumeric():
-            return s("turnippattern_nonnumeric_price"), None
-
-        buyprice, mondayprice = int(buyprice), int(mondayprice)
-        xval = mondayprice / buyprice
-        patterns = (
-            [1, 4]
-            if xval >= 0.91
-            else [2, 3, 4]
-            if xval >= 0.85
-            else [3, 4]
-            if xval >= 0.80
-            else [1, 4]
-            if xval >= 0.60
-            else [4]
-        )
-        lines = [s("turnippattern_header")]
-        if 1 in patterns:
-            lines.append(s("turnippattern_pattern1"))
-        if 2 in patterns:
-            lines.append(s("turnippattern_pattern2"))
-        if 3 in patterns:
-            lines.append(s("turnippattern_pattern3"))
-        lines.append(s("turnippattern_pattern4"))  # pattern 4 is always possible
-        return "\n".join(lines), None
-
-    def history_command(self, channel, author, params):
+    @command
+    def history(self, channel, author, params):
         """
         Show the historical turnip prices for a user. If no user is specified, it will
         display your own prices. | [user]
@@ -908,7 +895,8 @@ class Turbot(discord.Client):
             )
         return "\n".join(lines), None
 
-    def oops_command(self, channel, author, params):
+    @command
+    def oops(self, channel, author, params):
         """
         Remove your last logged turnip price.
         """
@@ -919,7 +907,8 @@ class Turbot(discord.Client):
         self.save_prices(prices)
         return s("oops", name=target_name), None
 
-    def clear_command(self, channel, author, params):
+    @command
+    def clear(self, channel, author, params):
         """
         Clears all of your own historical turnip prices.
         """
@@ -948,19 +937,22 @@ class Turbot(discord.Client):
             )
         return "\n".join(lines), None
 
-    def bestbuy_command(self, channel, author, params):
+    @command
+    def bestbuy(self, channel, author, params):
         """
         Finds the best (and most recent) buying prices logged in the last 12 hours.
         """
         return self._best(channel, author, "buy")
 
-    def bestsell_command(self, channel, author, params):
+    @command
+    def bestsell(self, channel, author, params):
         """
         Finds the best (and most recent) selling prices logged in the last 12 hours.
         """
         return self._best(channel, author, "sell")
 
-    def collect_command(self, channel, author, params):
+    @command
+    def collect(self, channel, author, params):
         """
         Mark collectables as donated to your museum. The names must match the in-game item
         name exactly. | <comma, separated, list, of, things>
@@ -1023,7 +1015,8 @@ class Turbot(discord.Client):
 
         return "\n".join(lines), None
 
-    def uncollect_command(self, channel, author, params):
+    @command
+    def uncollect(self, channel, author, params):
         """
         Unmark collectables as donated to your museum. The names must match the in-game
         item name exactly. | <comma, separated, list, of, things>
@@ -1084,7 +1077,8 @@ class Turbot(discord.Client):
 
         return "\n".join(lines), None
 
-    def search_command(self, channel, author, params):
+    @command
+    def search(self, channel, author, params):
         """
         Searches all users to see who needs the given collectables. The names must match
         the in-game item name, and more than one can be provided if separated by commas.
@@ -1152,13 +1146,15 @@ class Turbot(discord.Client):
             lines.append(s("search_invalid", items=", ".join(sorted(invalid))))
         return "\n".join(sorted(lines)), None
 
-    def allfossils_command(self, channel, author, params):
+    @command
+    def allfossils(self, channel, author, params):
         """
         Shows all possible fossils that you can donate to the museum.
         """
         return s("allfossils", list=", ".join(sorted(FOSSILS_SET))), None
 
-    def uncollected_command(self, channel, author, params):
+    @command
+    def uncollected(self, channel, author, params):
         """
         Lists all collectables that you still need to donate. If a user is provided, it
         gives the same information for that user instead. | [user]
@@ -1210,7 +1206,8 @@ class Turbot(discord.Client):
 
         return "\n".join(lines), None
 
-    def neededfossils_command(self, channel, author, params):
+    @command
+    def neededfossils(self, channel, author, params):
         """
         Lists all the needed fossils for all the channel members.
         """
@@ -1237,7 +1234,8 @@ class Turbot(discord.Client):
             return s("neededfossils_none"), None
         return "\n".join(sorted(lines)), None
 
-    def collected_command(self, channel, author, params):
+    @command
+    def collected(self, channel, author, params):
         """
         Lists all collectables that you have already donated. If a user is provided, it
         gives the same information for that user instead. | [user]
@@ -1287,7 +1285,8 @@ class Turbot(discord.Client):
             )
         return "\n".join(lines), None
 
-    def predict_command(self, channel, author, params):
+    @command
+    def predict(self, channel, author, params):
         """
         Get a link to a prediction calulator for a price history. | [user]
         """
@@ -1305,7 +1304,8 @@ class Turbot(discord.Client):
         url = f"{self.base_prophet_url}{query}"
         return s("predict", name=target_name, url=url), None
 
-    def friend_command(self, channel, author, params):
+    @command
+    def friend(self, channel, author, params):
         """
         Set your friend code. | <code>
         """
@@ -1319,7 +1319,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "friend", code)
         return s("friend", name=author), None
 
-    def creator_command(self, channel, author, params):
+    @command
+    def creator(self, channel, author, params):
         """
         Set your creator code. | <code>
         """
@@ -1333,7 +1334,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "creator", code)
         return s("creator", name=author), None
 
-    def fruit_command(self, channel, author, params):
+    @command
+    def fruit(self, channel, author, params):
         """
         Set your island's native fruit. | [apple|cherry|orange|peach|pear]
         """
@@ -1347,7 +1349,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "fruit", fruit)
         return s("fruit", name=author), None
 
-    def hemisphere_command(self, channel, author, params):
+    @command
+    def hemisphere(self, channel, author, params):
         """
         Set your hemisphere. | [Northern|Southern]
         """
@@ -1361,7 +1364,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "hemisphere", home)
         return s("hemisphere", name=author), None
 
-    def nickname_command(self, channel, author, params):
+    @command
+    def nickname(self, channel, author, params):
         """
         Set your nickname, such as your Switch user name. | <name>
         """
@@ -1372,7 +1376,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "nickname", name)
         return s("nickname", name=author), None
 
-    def timezone_command(self, channel, author, params):
+    @command
+    def timezone(self, channel, author, params):
         """
         Set your timezone. You can find a list of supported TZ names at
         <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> | <zone>
@@ -1387,7 +1392,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "timezone", zone)
         return s("timezone", name=author), None
 
-    def island_command(self, channel, author, params):
+    @command
+    def island(self, channel, author, params):
         """
         Set your island name. | <name>
         """
@@ -1398,7 +1404,8 @@ class Turbot(discord.Client):
         self.save_user_pref(author, "island", island)
         return s("island", name=author), None
 
-    def count_command(self, channel, author, params):
+    @command
+    def count(self, channel, author, params):
         """
         Provides a count of the number of pieces of collectables for the comma-separated
         list of users. | <list of users>
@@ -1446,7 +1453,8 @@ class Turbot(discord.Client):
 
         return "\n".join(lines), None
 
-    def art_command(self, channel, author, params):
+    @command
+    def art(self, channel, author, params):
         """
         Get info about pieces of art that are available | [List of art pieces]
         """
@@ -1565,7 +1573,8 @@ class Turbot(discord.Client):
         lines = [s(kind, **details(row)) for _, row in available.iterrows()]
         return "\n".join(add_header(sorted(lines)))
 
-    def fish_command(self, channel, author, params):
+    @command
+    def fish(self, channel, author, params):
         """
         Tells you what fish are available now in your hemisphere.
         | [name|leaving|arriving]
@@ -1575,7 +1584,8 @@ class Turbot(discord.Client):
             None,
         )
 
-    def bugs_command(self, channel, author, params):
+    @command
+    def bugs(self, channel, author, params):
         """
         Tells you what bugs are available now in your hemisphere.
         | [name|leaving|arriving]
@@ -1585,7 +1595,8 @@ class Turbot(discord.Client):
             None,
         )
 
-    def new_command(self, channel, author, params):
+    @command
+    def new(self, channel, author, params):
         """
         Tells you what new things available in your hemisphere right now.
         """
@@ -1650,7 +1661,8 @@ class Turbot(discord.Client):
 
         return embed
 
-    def info_command(self, channel, author, params):
+    @command
+    def info(self, channel, author, params):
         """
         Gives you information on a user. | [user]
         """
@@ -1676,7 +1688,8 @@ class Turbot(discord.Client):
 
         return s("info_not_found"), None
 
-    def about_command(self, channel, author, params):
+    @command
+    def about(self, channel, author, params):
         """
         Get information about Turbot.
         """

--- a/src/turbot/data/strings.yaml
+++ b/src/turbot/data/strings.yaml
@@ -80,7 +80,6 @@ fruit: Native fruit registered for $name.
 fruit_invalid: Your native fruit can be apple, cherry, orange, peach, or pear.
 fruit_no_params: Please provide your island's native fruit.
 graph_all_users: __**Historical Graph for All Users**__
-graph_user: __**Predictive Graph for $name**__
 hemisphere: Hemisphere preference registered for $name.
 hemisphere_bad_params: Please provide either "northern" or "southern" as your hemisphere
   name.
@@ -107,7 +106,9 @@ no_hemisphere: Please enter your hemisphere choice first using the !hemisphere c
 not_a_command: Sorry, there is no command named "$request"
 not_admin: User is not a Turbot Admin
 oops: '**Deleting last logged price for $name.**'
-predict: '$name''s turnip prediction link: $url'
+predict: '__**Predictive Graph for $name**__
+
+  Details: <$url>'
 price_time_invalid: Please provide both the day of the week and time of day.
 reset: '**Resetting data for a new week!**'
 search_all_not_needed: No one currently needs this.

--- a/src/turbot/data/strings.yaml
+++ b/src/turbot/data/strings.yaml
@@ -135,22 +135,6 @@ timezone: Timezone preference registered for $name.
 timezone_bad_params: Please provide a valid timezone name, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   for the complete list of TZ names.
 timezone_no_params: Please provide the name of your timezone.
-turnippattern_bad_params: 'Please provide Daisy Mae''s price and your Monday morning
-  price
-
-  eg. !turnippattern <buy price> <Monday morning sell price>'
-turnippattern_header: 'Based on your prices, you will see one of the following patterns
-  this week:'
-turnippattern_nonnumeric_price: Prices must be numbers.
-turnippattern_pattern1: '> **Random**: Prices are completely random. Sell when it
-  goes over your buying price.'
-turnippattern_pattern2: '> **Decreasing**: Prices will continuously fall.'
-turnippattern_pattern3: '> **Small Spike**: Prices fall until a spike occurs. The
-  price will go up three more times. Sell on the third increase for maximum profit.
-  Spikes only occur from Monday to Thursday.'
-turnippattern_pattern4: '> **Big Spike**: Prices fall until a small spike. Prices
-  then decrease before shooting up twice. Sell the second time prices shoot up after
-  the decrease for maximum profit. Spikes only occur from Monday to Thursday.'
 uncollect_art_already: 'The following pieces of art were already marked as not collected:
 
   > $items'

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -1,0 +1,65 @@
+__**Turbot Help!**__
+> **!about**
+>    Get information about Turbot.
+> 
+> **!allfossils**
+>    Shows all possible fossils that you can donate to the museum.
+> 
+> **!art [List of art pieces]**
+>    Get info about pieces of art that are available 
+> 
+> **!bestbuy**
+>    Finds the best (and most recent) buying prices logged in the last 12 hours.
+> 
+> **!bestsell**
+>    Finds the best (and most recent) selling prices logged in the last 12 hours.
+> 
+> **!bugs [name, leaving, arriving]**
+>    Tells you what bugs are available now in your hemisphere.
+> 
+> **!buy <price> [day time]**
+>    Log the price that you can buy turnips from Daisy Mae on your island.
+> 
+> **!clear**
+>    Clears all of your own historical turnip prices.
+> 
+> **!collect <comma, separated, list, of, things>**
+>    Mark collectables as donated to your museum. The names must match the in-game item name exactly. 
+> 
+> **!collected [user]**
+>    Lists all collectables that you have already donated. If a user is provided, it gives the same information for that user instead. 
+> 
+> **!count <list of users>**
+>    Provides a count of the number of pieces of collectables for the comma-separated list of users. 
+> 
+> **!creator <code>**
+>    Set your creator code. 
+> 
+> **!fish [name, leaving, arriving]**
+>    Tells you what fish are available now in your hemisphere.
+> 
+> **!friend <code>**
+>    Set your friend code. 
+> 
+> **!fruit [apple, cherry, orange, peach, pear]**
+>    Set your island's native fruit. 
+> 
+> **!graph**
+>    Generates a historical graph of turnip prices for all users.
+> 
+> **!help**
+>    Shows this help screen.
+> 
+> **!hemisphere [Northern, Southern]**
+>    Set your hemisphere. 
+> 
+> **!history [user]**
+>    Show the historical turnip prices for a user. If no user is specified, it will display your own prices. 
+> 
+> **!info [user]**
+>    Gives you information on a user. 
+> 
+> **!island <name>**
+>    Set your island name. 
+> 
+> **!lastweek**

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,0 +1,36 @@
+>    Displays the final graph from the last week before the data was reset.
+> 
+> **!neededfossils**
+>    Lists all the needed fossils for all the channel members.
+> 
+> **!new**
+>    Tells you what new things available in your hemisphere right now.
+> 
+> **!nickname <name>**
+>    Set your nickname, such as your Switch user name. 
+> 
+> **!oops**
+>    Remove your last logged turnip price.
+> 
+> **!predict [user]**
+>    Get a link to a prediction calculator for a price history. 
+> 
+> **!reset**
+>    Only Turbot Admin members can run this command. Generates a final graph for use with !lastweek and resets all data for all users.
+> 
+> **!search <list of collectables>**
+>    Searches all users to see who needs the given collectables. The names must match the in-game item name, and more than one can be provided if separated by commas.
+> 
+> **!sell <price> [day time]**
+>    Log the price that you can sell turnips for on your island.
+> 
+> **!timezone <zone>**
+>    Set your timezone. You can find a list of supported TZ names at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> 
+> 
+> **!uncollect <comma, separated, list, of, things>**
+>    Unmark collectables as donated to your museum. The names must match the in-game item name exactly. 
+> 
+> **!uncollected [user]**
+>    Lists all collectables that you still need to donate. If a user is provided, it gives the same information for that user instead. 
+> 
+> turbot created by TheAstropath

--- a/tests/snapshots/test_on_message_turnippattern_happy_paths_0.txt
+++ b/tests/snapshots/test_on_message_turnippattern_happy_paths_0.txt
@@ -1,4 +1,0 @@
-Based on your prices, you will see one of the following patterns this week:
-> **Decreasing**: Prices will continuously fall.
-> **Small Spike**: Prices fall until a spike occurs. The price will go up three more times. Sell on the third increase for maximum profit. Spikes only occur from Monday to Thursday.
-> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.

--- a/tests/snapshots/test_on_message_turnippattern_happy_paths_1.txt
+++ b/tests/snapshots/test_on_message_turnippattern_happy_paths_1.txt
@@ -1,3 +1,0 @@
-Based on your prices, you will see one of the following patterns this week:
-> **Random**: Prices are completely random. Sell when it goes over your buying price.
-> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.

--- a/tests/snapshots/test_on_message_turnippattern_happy_paths_2.txt
+++ b/tests/snapshots/test_on_message_turnippattern_happy_paths_2.txt
@@ -1,2 +1,0 @@
-Based on your prices, you will see one of the following patterns this week:
-> **Big Spike**: Prices fall until a small spike. Prices then decrease before shooting up twice. Sell the second time prices shoot up after the decrease for maximum profit. Spikes only occur from Monday to Thursday.

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import random
+import re
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
@@ -851,35 +852,6 @@ class TestTurbot:
             f"> **{BUDDY}:** {turbot.h(buddy_now)} for 60 bells\n"
             f"> **{FRIEND}:** {turbot.h(friend_now)} for 100 bells"
         )
-
-    async def test_on_message_turnippattern_happy_paths(self, client, channel, snap):
-        await client.on_message(MockMessage(someone(), channel, "!turnippattern 100 86"))
-        snap(channel.last_sent_response)
-
-        await client.on_message(MockMessage(someone(), channel, "!turnippattern 100 99"))
-        snap(channel.last_sent_response)
-
-        await client.on_message(MockMessage(someone(), channel, "!turnippattern 100 22"))
-        snap(channel.last_sent_response)
-
-    async def test_on_message_turnippattern_invalid_params(self, client, channel):
-        await client.on_message(MockMessage(someone(), channel, "!turnippattern 100"))
-        assert channel.last_sent_response == (
-            "Please provide Daisy Mae's price and your Monday morning price\n"
-            "eg. !turnippattern <buy price> <Monday morning sell price>"
-        )
-
-        await client.on_message(MockMessage(someone(), channel, "!turnippattern 1 2 3"))
-        assert channel.last_sent_response == (
-            "Please provide Daisy Mae's price and your Monday morning price\n"
-            "eg. !turnippattern <buy price> <Monday morning sell price>"
-        )
-
-    async def test_on_message_turnippattern_nonnumeric_prices(self, client, channel):
-        await client.on_message(
-            MockMessage(someone(), channel, "!turnippattern something nothing")
-        )
-        assert channel.last_sent_response == ("Prices must be numbers.")
 
     async def test_on_message_graph_without_user(self, client, channel, graph):
         await client.on_message(MockMessage(FRIEND, channel, "!buy 100"))
@@ -2408,6 +2380,16 @@ class TestCodebase:
                 "snapshots are harder to reason about when they fail. Whenever possilbe "
                 "a test with inline data is much easier to reason about and refactor."
             )
+
+    def test_readme_commands(self, client):
+        """Checks that all commands are documented in our readme."""
+        with open(REPO_ROOT / "README.md") as f:
+            readme = f.read()
+
+        documented = set(re.findall("^- `!([a-z]+)`: .*$", readme, re.MULTILINE))
+        implemented = set(client.commands)
+
+        assert documented == implemented
 
 
 # These tests will fail in isolation, you must run the full test suite for them to pass.


### PR DESCRIPTION
Removes the turnippattern command as `!predict` and `!graph username` give much better information, I'm also a bit worried that sometimes turnippattern can be inaccurate. Regardless, no one seems to use it anymore 🤷‍♀️ 

Also I removed the weird magic where turbot automatically found methods with names like `foo_command` and instead introduced the more explicit `@command` decorator that lets you say exactly what methods should be considered commands. This also cleans up the logic in `process()` and `help()` and in the test suite.

Added a codebase test to check that the readme references all the commands that are available after noticing that we didn't have a reference to `!bestbuy` in there.