### PR TITLE
Fixes an issue with buy at set time

### DIFF
--- a/src/turbot/__init__.py
+++ b/src/turbot/__init__.py
@@ -95,13 +95,13 @@ USER_PREFRENCES = [
 ]
 
 DAYS = {
-    "sunday": 0,
     "monday": 1,
     "tuesday": 2,
     "wednesday": 3,
     "thursday": 4,
     "friday": 5,
     "saturday": 6,
+    "sunday": 7,
 }
 
 
@@ -568,7 +568,9 @@ class Turbot(discord.Client):
             return [None] * 13
 
         buy_date = recent_buy.timestamp.iloc[0]
-        if buy_date.to_pydatetime().isoweekday() != 7:  # buy isn't on a sunday
+        if (
+            buy_date.to_pydatetime().isoweekday() != DAYS["sunday"]
+        ):  # buy isn't on a sunday
             return [None] * 13
 
         buy_price = int(recent_buy.price.iloc[0])
@@ -588,7 +590,7 @@ class Turbot(discord.Client):
         groups = sells.set_index("timestamp").groupby(pd.Grouper(freq="D"))
         for day, df in groups:
             day_of_week = day.to_pydatetime().isoweekday()
-            if day_of_week == 7:  # no sells allowed on sundays
+            if day_of_week == DAYS["sunday"]:  # no sells allowed on sundays
                 continue
             for ts, row in df.iterrows():
                 if ts.hour < 12:  # am
@@ -792,7 +794,7 @@ class Turbot(discord.Client):
         now = self.to_usertime(user_id, datetime.now(pytz.utc))
         start = now - timedelta(days=now.isoweekday() % 7)  # start of week
         start = datetime(start.year, start.month, start.day, tzinfo=start.tzinfo)
-        day_offset = DAYS[day_of_week]
+        day_offset = DAYS[day_of_week] % 7
         hour_offset = 13 if time_of_day == "evening" else 0
         return start + timedelta(days=day_offset, hours=hour_offset)
 

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -364,8 +364,9 @@ class TestTurbot:
             MockMessage(author, channel, f"!pref timezone {author_tz.zone}")
         )
 
-        sunday_am = datetime(2020, 4, 26, 9, tzinfo=pytz.utc)
+        sunday_am = datetime(2020, 4, 26, 9, tzinfo=author_tz)
         freezer.move_to(sunday_am)
+        assert sunday_am.isoweekday() == turbot.DAYS["sunday"]
         await client.on_message(MockMessage(author, channel, f"!buy 90"))
 
         amount = 100
@@ -426,6 +427,23 @@ class TestTurbot:
             None,
             None,
         ]
+
+    async def test_get_user_timeline_buy_at_sunday(self, client, channel, lines, freezer):
+        author = someone()
+        author_tz = pytz.timezone("America/Los_Angeles")
+        await client.on_message(
+            MockMessage(author, channel, f"!pref timezone {author_tz.zone}")
+        )
+
+        sunday_am = datetime(2020, 5, 4, 6, tzinfo=pytz.utc)
+        freezer.move_to(sunday_am + timedelta(days=2, hours=12))
+        await client.on_message(MockMessage(author, channel, f"!buy 90 sunday morning"))
+
+        await client.on_message(MockMessage(author, channel, f"!history"))
+        assert channel.last_sent_response == (
+            f"__**Historical info for {author}**__\n"
+            "> Can buy turnips from Daisy Mae for 90 bells 3 days ago"
+        )
 
     async def test_get_user_timeline_no_sells(self, client, channel, lines, freezer):
         author = someone()


### PR DESCRIPTION
Found a bug where `!buy 90 sunday morning` would set the buy price's timestamp to the following Sunday instead of the previous Sunday. This fixes it and adds a test to ensure it doesn't regress.