### PR TITLE
Don't show error graphs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = src/turbot
+omit = src/turbot/_version.py
 
 [report]
 ignore_errors = True


### PR DESCRIPTION
Sometimes the turnips library fails to generate a graph. In that case, don't show it. We still have the turnipprophet.io link to provide to the user (and sometimes, depending on how wild the user's data it, even that website won't show a valid graph).

Resolves #151