### PR TITLE
Count defaults to yourself

### DIFF
--- a/src/turbot/__init__.py
+++ b/src/turbot/__init__.py
@@ -1157,22 +1157,23 @@ class Turbot(discord.Client):
     def count(self, channel, author, params):
         """
         Provides a count of the number of pieces of collectables for the comma-separated
-        list of users. | <list of users>
+        list of users. | [comma, separated, list, of, users]
         """
         if not params:
-            return s("count_no_params"), None
-
-        users = set(sanitize_collectable(item) for item in " ".join(params).split(","))
-
-        valid = []
-        invalid = []
-        for user in users:
-            user_name = discord_user_name(channel, user)
-            user_id = discord_user_id(channel, user_name)
-            if user_name and user_id:
-                valid.append((user_name, user_id))
-            else:
-                invalid.append(user)
+            user = discord_user_from_id(channel, author.id)
+            valid = [(user.name, user.id)]
+            invalid = []
+        else:
+            users = set(sanitize_collectable(p) for p in " ".join(params).split(","))
+            valid = []
+            invalid = []
+            for user in users:
+                user_name = discord_user_name(channel, user)
+                user_id = discord_user_id(channel, user_name)
+                if user_name and user_id:
+                    valid.append((user_name, user_id))
+                else:
+                    invalid.append(user)
 
         lines = []
 

--- a/src/turbot/data/strings.yaml
+++ b/src/turbot/data/strings.yaml
@@ -96,7 +96,6 @@ count_fossils_valid: '> **$name** has $count fossils remaining.'
 count_fossils_valid_header: __**Fossil Count**__
 count_invalid: '> $name'
 count_invalid_header: __**Did not recognize the following names**__
-count_no_params: Please provide at least one user name to search for.
 count_songs_valid: '> **$name** has $count songs remaining.'
 count_songs_valid_header: __**Songs Count**__
 creator_invalid: Your Animal Crossing creator code should be 12 numbers.

--- a/tests/snapshots/test_on_message_count_no_params_0.txt
+++ b/tests/snapshots/test_on_message_count_no_params_0.txt
@@ -1,0 +1,10 @@
+__**Fossil Count**__
+> **buddy** has 73 fossils remaining.
+__**Bugs Count**__
+> **buddy** has 80 bugs remaining.
+__**Fish Count**__
+> **buddy** has 80 fish remaining.
+__**Art Count**__
+> **buddy** has 43 pieces of art remaining.
+__**Songs Count**__
+> **buddy** has 95 songs remaining.

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -23,7 +23,7 @@ __**Turbot Help!**__
 > **!collected [user]**
 >    Lists all collectables that you have already donated. If a user is provided, it gives the same information for that user instead. 
 > 
-> **!count <list of users>**
+> **!count [comma, separated, list, of, users]**
 >    Provides a count of the number of pieces of collectables for the comma-separated list of users. 
 > 
 > **!fish [name, leaving, arriving]**

--- a/tests/test_turbot.py
+++ b/tests/test_turbot.py
@@ -1228,13 +1228,12 @@ class TestTurbot:
             "> anime waifu"
         )
 
-    async def test_on_message_count_no_params(self, client, channel, lines):
-        await client.on_message(MockMessage(someone(), channel, "!count"))
-        assert channel.last_sent_response == (
-            "Please provide at least one user name to search for."
-        )
+    async def test_on_message_count_no_params(self, client, channel, snap):
+        await client.on_message(MockMessage(BUDDY, channel, f"!count"))
+        snap(channel.last_sent_response)
+        assert len(channel.all_sent_calls) == 1
 
-    async def test_on_message_count_bad_name(self, client, channel, lines):
+    async def test_on_message_count_bad_name(self, client, channel):
         await client.on_message(MockMessage(someone(), channel, f"!count {PUNK.name}"))
         assert channel.last_sent_response == (
             f"__**Did not recognize the following names**__\n> {PUNK.name}"


### PR DESCRIPTION
Makes `!count` by itself return results for yourself like how the other commands related to collectables work.