### PR TITLE
Changes to support postgresql

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.7, 3.8]
+        database-url: ["", "postgresql://postgres:postgres@localhost:5432/postgres"]
 
     steps:
     - name: Checkout Source
@@ -20,6 +31,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install sqlite3
+      run: sudo apt-get install sqlite3
+
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -27,6 +41,8 @@ jobs:
 
     - name: Run Tests
       run: tox
+      env:
+        TURBOT_DB_URL: ${{ matrix.database-url }}
 
     - name: Send Reports to Codecov
       uses: codecov/codecov-action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,19 +216,21 @@ looks good.
 ## Database Migrations
 
 We use [alembic][alembic] for database migrations. It can detect changes you've
-made to an existing database and generate migration scripts necessary to apply
-_and_ reverse those changes. First, make the changes in the database and in
-the models. Then to autogenerate migration scripts use:
+made compared to an existing database and generate migration scripts necessary
+to apply _and_ reverse those changes. First, make the changes to the data
+models. Alembic can detect differences between an existing database and changes
+made to the models. To autogenerate migration scripts that will bring the
+database inline with the changes you've made to the models, run:
 
 ```shell
 poetry run scripts/create_db_revision.py \
-    "<your sqlalchemy database connection url>" \
+    "<your-turbot-database-url>" \
     "<Some description of your changes>"
 ```
 
 This will create a revision script in the `src/turbot/versions/versions`
 directory with a name like `REVISIONID_some_description_of_your_changes.py`.
-You will have to edit this script manually to ensure that it is correct as
+You may have to edit this script manually to ensure that it is correct as
 the autogenerate facility of `alembic revision` is not perfect, especially
 if you are using sqlite which doesn't support many database features.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,5 +213,25 @@ looks good.
 > need to have non-interactive `poetry publish` enabled by running:
 > `poetry config pypi-token.pypi "YOUR-PYPI-TOKEN-GOES-HERE"`.
 
+## Database Migrations
+
+We use [alembic][alembic] for database migrations. It can detect changes you've
+made to an existing database and generate migration scripts necessary to apply
+_and_ reverse those changes. First, make the changes in the database and in
+the models. Then to autogenerate migration scripts use:
+
+```shell
+poetry run scripts/create_db_revision.py \
+    "<your sqlalchemy database connection url>" \
+    "<Some description of your changes>"
+```
+
+This will create a revision script in the `src/turbot/versions/versions`
+directory with a name like `REVISIONID_some_description_of_your_changes.py`.
+You will have to edit this script manually to ensure that it is correct as
+the autogenerate facility of `alembic revision` is not perfect, especially
+if you are using sqlite which doesn't support many database features.
+
+[alembic]:          https://alembic.sqlalchemy.org/
 [black]:            https://github.com/psf/black
 [wiki]:             https://animalcrossing.fandom.com/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,7 +18,10 @@ doesn't get blown away whenever you kill and remove the image.
 docker run \
     -e TURBOT_TOKEN="<your-discord-bot-token>" \
     -e TURBOT_CHANNELS="<some;channels;here>" \
+    -e TURBOT_DB_URL="<your-turbot-database-url> \
     -v "$(pwd)/db":/db \
     --rm
     turbot
 ```
+
+> **Note:** Don't set `TURBOT_DB_URL` if you want to use sqlite3.

--- a/HEROKU.md
+++ b/HEROKU.md
@@ -25,6 +25,7 @@ repository. If you'd rather go through the process manually, read further.
     heroku git:remote -a <your-heroku-app-name>
     heroku config:set TURBOT_TOKEN=<your-discord-bot-token>
     heroku config:set TURBOT_CHANNELS=<your;authorized;channel;names;>
+    heroku config:set TURBOT_DB_URL=<your-turbot-database-url>
     heroku buildpacks:clear
     heroku buildpacks:add heroku/python
     git push heroku master
@@ -32,6 +33,8 @@ repository. If you'd rather go through the process manually, read further.
 
 7. Go to the resources tab in your Heroku app, you should see a worker there.
    Click the edit button and turn the worker on.
+
+> **Note:** Don't set `TURBOT_DB_URL` if you want to use sqlite3.
 
 At this point your worker should be running. If you encounter issues, check your
 Heroku app logs. You can stop the worker from within the settings tab where you

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ named `channels.txt` where each line of the file is a channel name. You can
 also specify them via the environment variable `TURBOT_CHANNELS` as a semicolon
 delimited string, for example: `export TURBOT_CHANNELS="some;channels;here"`.
 
+By default Turbot will use sqlite3 as its database. You can however choose to
+use another database by providing a [SQLAlchemy Connection URL][db-url]. This
+can be done via the `--database-url` command line option or the environment
+variable `TURBOT_DB_URL`. Note that, at the time of this writing, Turbot is only
+tested against sqlite3 and PostgreSQL.
+
 More usage help can be found by running `turbot --help`.
 
 ## ⚛️ Heroku Support
@@ -129,6 +135,7 @@ You can also run Turbot via docker. See
 [codecov-badge]:    https://codecov.io/gh/theastropath/turbot/branch/master/graph/badge.svg
 [codecov]:          https://codecov.io/gh/theastropath/turbot
 [contributors]:     https://github.com/theastropath/turbot/graphs/contributors
+[db-url]:           https://docs.sqlalchemy.org/en/latest/core/engines.html
 [deploy]:           https://heroku.com/deploy
 [lexicalunit]:      http://github.com/lexicalunit
 [mit-badge]:        https://img.shields.io/badge/License-MIT-yellow.svg

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ critters you've already caught and will tailor their responses to the user.
 - `!fish`: Get information on fish
 - `!new`: Get information on newly available fish and bugs
 
+### 👑 Administration
+
+- `!authorize`: Configure which channels Turbot can operate in
+
 ## 🤖 Running Turbot
 
 First install `turbot` using [`pip`](https://pip.pypa.io/en/stable/):
@@ -90,7 +94,7 @@ pip install turbot
 Then you must configure two things:
 
 1. Your Discord bot token.
-2. The list of channels you want `turbot` to monitor.
+2. The list of channels you want `turbot` to monitor. (Default: All channels)
 
 To provide your Discord bot token either set an environment variable named
 `TURBOT_TOKEN` to the token or paste it into a file named `token.txt`.
@@ -100,6 +104,8 @@ any number of `--channel "name"` options. Alternatively you can create a file
 named `channels.txt` where each line of the file is a channel name. You can
 also specify them via the environment variable `TURBOT_CHANNELS` as a semicolon
 delimited string, for example: `export TURBOT_CHANNELS="some;channels;here"`.
+You can also leave this unspecified and Turbot will operate within all channels,
+then you can specify a smaller set of channels using the `!authorize` command.
 
 By default Turbot will use sqlite3 as its database. You can however choose to
 use another database by providing a [SQLAlchemy Connection URL][db-url]. This

--- a/app.json
+++ b/app.json
@@ -12,6 +12,10 @@
     "TURBOT_CHANNELS": {
       "description": "List of channel names seperated by ;",
       "value": "general;"
+    },
+    "TURBOT_DB_URL": {
+      "description": "Your SQLAlchemy database connection url, leave blank for sqlite3",
+      "value": ""
     }
   },
   "formation": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -580,6 +580,14 @@ version = "3.0.5"
 wcwidth = "*"
 
 [[package]]
+category = "main"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg2"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "2.8.5"
+
+[[package]]
 category = "dev"
 description = "Run a subprocess in a pseudo terminal"
 marker = "sys_platform != \"win32\""
@@ -973,7 +981,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a2a11e0fcae3014c5545bac4e0542ac4982443d27db5d60285ebd919a12d6117"
+content-hash = "e493db5413d883523efb90af6e96c254f1e28184028f8fbc90cdf56262c9b06a"
 python-versions = '>=3.7,<4'
 
 [metadata.files]
@@ -1369,6 +1377,21 @@ pluggy = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.5-py3-none-any.whl", hash = "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"},
     {file = "prompt_toolkit-3.0.5.tar.gz", hash = "sha256:563d1a4140b63ff9dd587bda9557cffb2fe73650205ab6f4383092fb882e7dc8"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.8.5-cp27-cp27m-win32.whl", hash = "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf"},
+    {file = "psycopg2-2.8.5-cp27-cp27m-win_amd64.whl", hash = "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb"},
+    {file = "psycopg2-2.8.5-cp34-cp34m-win32.whl", hash = "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72"},
+    {file = "psycopg2-2.8.5-cp34-cp34m-win_amd64.whl", hash = "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e"},
+    {file = "psycopg2-2.8.5-cp35-cp35m-win32.whl", hash = "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055"},
+    {file = "psycopg2-2.8.5-cp35-cp35m-win_amd64.whl", hash = "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52"},
+    {file = "psycopg2-2.8.5-cp36-cp36m-win32.whl", hash = "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c"},
+    {file = "psycopg2-2.8.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81"},
+    {file = "psycopg2-2.8.5-cp37-cp37m-win32.whl", hash = "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9"},
+    {file = "psycopg2-2.8.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080"},
+    {file = "psycopg2-2.8.5-cp38-cp38-win32.whl", hash = "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7"},
+    {file = "psycopg2-2.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535"},
+    {file = "psycopg2-2.8.5.tar.gz", hash = "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ hupper = "^1.10.2"
 matplotlib = "^3.2.1"
 numpy = "^1.18.4"
 pandas = "^1.0.3"
+psycopg2 = "^2.8.5"
 pydantic = "^1.5.1"
 python = '>=3.7,<4'
 python-dateutil = "^2.8.1"

--- a/scripts/create_db_revision.py
+++ b/scripts/create_db_revision.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import sys
+from os.path import dirname, realpath
+from pathlib import Path
+
+import alembic
+import alembic.config
+
+SRC_ROOT = Path(dirname(realpath(__file__))).parent
+ASSETS_DIR = SRC_ROOT / "src" / "turbot" / "assets"
+ALEMBIC_INI = ASSETS_DIR / "alembic.ini"
+VERSIONS_DIR = SRC_ROOT / "src" / "turbot" / "versions"
+
+url = sys.argv[1]
+message = sys.argv[2]
+
+config = alembic.config.Config(str(ALEMBIC_INI))
+config.set_main_option("script_location", str(VERSIONS_DIR))
+config.set_main_option("sqlalchemy.url", url)
+alembic.command.stamp(config, "head")
+alembic.command.revision(config, message=message, autogenerate=True)

--- a/scripts/create_db_revision.py
+++ b/scripts/create_db_revision.py
@@ -18,5 +18,4 @@ message = sys.argv[2]
 config = alembic.config.Config(str(ALEMBIC_INI))
 config.set_main_option("script_location", str(VERSIONS_DIR))
 config.set_main_option("sqlalchemy.url", url)
-alembic.command.stamp(config, "head")
 alembic.command.revision(config, message=message, autogenerate=True)

--- a/src/turbot/assets/alembic.ini
+++ b/src/turbot/assets/alembic.ini
@@ -1,3 +1,6 @@
+[alembic]
+; script_location and sqlalchemy.url are set dynamically
+
 [post_write_hooks]
 hooks=black
 black.type=console_scripts

--- a/src/turbot/assets/strings.yaml
+++ b/src/turbot/assets/strings.yaml
@@ -147,7 +147,8 @@ pref_no_params: Please provide a preference and a value, possible preferences in
 pref_no_value: Please provide the value for your $pref preference.
 price_time_invalid: Please provide both the day of the week and time of day.
 reset: '**Resetting data for a new week!**'
-search_all_not_needed: No one currently needs this.
+search_all_not_needed: No one currently needs this. Note that new users must have
+  collected at least one item before they are considered for this search.
 search_art_row: '> $name needs arts: $items'
 search_bugs_row: '> $name needs bugs: $items'
 search_fish_row: '> $name needs fish: $items'

--- a/src/turbot/assets/strings.yaml
+++ b/src/turbot/assets/strings.yaml
@@ -15,6 +15,7 @@ art_invalid: 'Did not recognize the following pieces of art:
 art_real: '> **$name** is always genuine.
 
   > **Real:** <$real_url>'
+authorize: 'Turbot is now authorized to operate in the following channels: $channels.'
 best: '> **$name:** $timestamp for $price bells'
 best_buy_header: __**Best Buying Prices in the Last 12 Hours**__
 best_invalid_param: Please choose either best buy or best sell.
@@ -133,7 +134,7 @@ needed_none: No $kind are known to be needed at this time, new users must collec
 no_hemisphere: Please enter your hemisphere choice first using the !pref hemisphere
   command.
 not_a_command: Sorry, there is no command named "$request"
-not_admin: User is not a Turbot Admin
+not_admin: Sorry, you are not a Turbot Admin.
 oops: '**Deleting last logged price for $name.**'
 oops_no_data: Sorry, you have no data to delete.
 predict: '__**Predictive Graph for $name**__

--- a/src/turbot/data.py
+++ b/src/turbot/data.py
@@ -21,42 +21,42 @@ Base = declarative_base()
 class Fossil(Base):
     __tablename__ = "fossils"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     name = Column(String(50), nullable=False)
 
 
 class Art(Base):
     __tablename__ = "art"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     name = Column(String(50), nullable=False)
 
 
 class Fish(Base):
     __tablename__ = "fish"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     name = Column(String(50), nullable=False)
 
 
 class Bug(Base):
     __tablename__ = "bugs"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     name = Column(String(50), nullable=False)
 
 
 class Song(Base):
     __tablename__ = "songs"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     name = Column(String(50), nullable=False)
 
 
 class Price(Base):
     __tablename__ = "prices"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(BigInteger, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"), nullable=False)
     kind = Column(String(20), nullable=False)
     price = Column(Integer, nullable=False)
     timestamp = Column(String(30), nullable=False)
@@ -87,8 +87,9 @@ class User(Base):
 
 class AuthorizedChannel(Base):
     __tablename__ = "authorized_channels"
+    id = Column(Integer, primary_key=True, nullable=False)
     guild = Column(BigInteger, primary_key=True, nullable=False)
-    name = Column(String(100))
+    name = Column(String(100), nullable=False)
 
 
 def create_all(connection, db_url):

--- a/src/turbot/data.py
+++ b/src/turbot/data.py
@@ -5,7 +5,7 @@ import alembic
 import alembic.config
 import pandas as pd
 import pytz
-from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 
@@ -21,42 +21,42 @@ Base = declarative_base()
 class Fossil(Base):
     __tablename__ = "fossils"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     name = Column(String(50), nullable=False)
 
 
 class Art(Base):
     __tablename__ = "art"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     name = Column(String(50), nullable=False)
 
 
 class Fish(Base):
     __tablename__ = "fish"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     name = Column(String(50), nullable=False)
 
 
 class Bug(Base):
     __tablename__ = "bugs"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     name = Column(String(50), nullable=False)
 
 
 class Song(Base):
     __tablename__ = "songs"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     name = Column(String(50), nullable=False)
 
 
 class Price(Base):
     __tablename__ = "prices"
     id = Column(Integer, primary_key=True, nullable=False)
-    author = Column(Integer, ForeignKey("users.author"))
+    author = Column(BigInteger, ForeignKey("users.author"))
     kind = Column(String(20), nullable=False)
     price = Column(Integer, nullable=False)
     timestamp = Column(String(30), nullable=False)
@@ -64,7 +64,7 @@ class Price(Base):
 
 class User(Base):
     __tablename__ = "users"
-    author = Column(Integer, primary_key=True, nullable=False)
+    author = Column(BigInteger, primary_key=True, nullable=False)
     hemisphere = Column(String(15))
     hemisphere = Column(String(50))
     timezone = Column(String(50))

--- a/src/turbot/data.py
+++ b/src/turbot/data.py
@@ -85,6 +85,12 @@ class User(Base):
         return pytz.timezone(self.timezone) if self.timezone else pytz.UTC
 
 
+class AuthorizedChannel(Base):
+    __tablename__ = "authorized_channels"
+    guild = Column(BigInteger, primary_key=True, nullable=False)
+    name = Column(String(100))
+
+
 def create_all(connection, db_url):
     config = alembic.config.Config(str(ALEMBIC_INI))
     config.set_main_option("script_location", str(VERSIONS_DIR))
@@ -125,7 +131,7 @@ class Data:
             data_type: {
                 column: (
                     "int64"
-                    if column in ["author", "price"]
+                    if column in ["author", "guild", "price"]
                     else "datetime64[ns, UTC]"
                     if column == "timestamp"
                     else "str"

--- a/src/turbot/versions/versions/33940279af35_keep_track_of_authorized_channels_per_.py
+++ b/src/turbot/versions/versions/33940279af35_keep_track_of_authorized_channels_per_.py
@@ -1,0 +1,29 @@
+"""Keep track of authorized channels per server
+
+Revision ID: 33940279af35
+Revises: 9b107d322c46
+Create Date: 2020-05-17 18:42:33.659939
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "33940279af35"
+down_revision = "9b107d322c46"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "authorized_channels",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild", sa.BIGINT(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("authorized_channels")

--- a/src/turbot/versions/versions/9b107d322c46_use_bigint_for_author_ids.py
+++ b/src/turbot/versions/versions/9b107d322c46_use_bigint_for_author_ids.py
@@ -1,0 +1,61 @@
+"""Use BIGINT for author ids
+
+Revision ID: 9b107d322c46
+Revises: 1afdca2a2389
+Create Date: 2020-05-17 11:34:03.356515
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b107d322c46"
+down_revision = "1afdca2a2389"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("bugs") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("fossils") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("songs") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("art") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("fish") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("prices") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+    with op.batch_alter_table("users") as b:
+        b.alter_column("author", existing_type=sa.Integer(), type_=sa.BigInteger())
+
+
+def downgrade():
+    with op.batch_alter_table("bugs") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("fossils") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("songs") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("art") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("fish") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("prices") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())
+
+    with op.batch_alter_table("users") as b:
+        b.alter_column("author", existing_type=sa.BigInteger(), type_=sa.Integer())

--- a/tests/snapshots/test_on_message_help_0.txt
+++ b/tests/snapshots/test_on_message_help_0.txt
@@ -6,6 +6,9 @@ __**Turbot Help!**__
 **!art** _[comma, separated, list, of, art, pieces]_
 >  Get info about pieces of art that are available
 
+**!authorize**
+>  Set the list of channels where Turbot is authorized to respond. | <your, list, of, channels>
+
 **!best** _[buy|sell]_
 >  Finds the best, most recent, buy or sell price currently available. The default is to look for the best sell.
 
@@ -55,8 +58,3 @@ __**Turbot Help!**__
 >  Remove your last logged turnip price.
 
 **!predict** _[user]_
->  Get a link to a prediction calculator for a price history. 
-
-**!pref** _<preference> <value>_
->  Set one of your user preferences. 
-

--- a/tests/snapshots/test_on_message_help_1.txt
+++ b/tests/snapshots/test_on_message_help_1.txt
@@ -1,3 +1,8 @@
+>  Get a link to a prediction calculator for a price history. 
+
+**!pref** _<preference> <value>_
+>  Set one of your user preferences. 
+
 **!reset**
 >  Only Turbot Admin members can run this command. Generates a final graph for use with !lastweek and resets all data for all users.
 


### PR DESCRIPTION
When I started testing using PostgreSQL as the backend it became obvious quickly that some changes would need to be made to accommodate it.

- The database adapter for PostgreSQL, `psycopg2`, needed to be added.
- The `GROUP BY` query in sqlite doesn't work in a real database like PostgreSQL, so I re-wrote it in such a way that it will work on both sqlite and real databases.
- Since sqlite treats all integral data types the same, it didn't matter if we used `INTEGER` or `BIGINT` for the `author` columns. However in any real database you will need `BIGINT` for these. So I added a migration to alter those columns. This doesn't actually affect the behavior of sqlite at all, but it makes things work on PostgreSQL.
- If you're using PostgreSQL for tests you have to ensure that the tests have a clean slate before each test. You got this for free with sqlite so I had to write some new code to ensure this happens.
- For real databases you also need to make sure you are properly closing connections in the test suite.
- Because sqlite completely ignores FK constraints, I needed to update some of the Figures tests to ensure that those constrains were actually satisfied for them to pass on PostgreSQL.

I also added a script and some documentation to help support future database migrations.


TODO:

- [x] Add a CI matrix to run tests against both sqlite and postgresql.
- [x] Resolves https://github.com/theastropath/turbot/issues/174